### PR TITLE
Add test for GeneratorExit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="synchronicity", version="0.2.6")
+setup(name="synchronicity", version="0.2.7")


### PR DESCRIPTION
I thought this was a problem in synchronicity. It wasn't, but it's probably not a bad idea to keep the test.