### PR TITLE
Workaround for bug in Python 3.7.8 and earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7.8", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Python ${{ matrix.python-version }}

--- a/synchronicity/contextlib.py
+++ b/synchronicity/contextlib.py
@@ -1,3 +1,4 @@
+import sys
 from .exceptions import UserCodeException, unwrap_coro_exception
 
 
@@ -30,6 +31,12 @@ def get_ctx_mgr_cls():
                 else:
                     raise RuntimeError("generator didn't stop")
             else:
+                if sys.version_info < (3, 7, 9) and typ == GeneratorExit:
+                    # fix for weird error pre 3.7.9 https://bugs.python.org/issue33786
+                    # not sure if it breaks something else though so lets version gate it
+                    typ = StopAsyncIteration
+                    value = typ()
+
                 if value is None:
                     value = typ()
                 try:

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -1,7 +1,9 @@
 import asyncio
+from contextlib import asynccontextmanager
 import pytest
 
 from synchronicity import Synchronizer
+from synchronicity.interface import Interface
 
 
 async def noop():
@@ -121,3 +123,20 @@ async def test_asynccontextmanager_with_in_async():
     with pytest.raises(RuntimeError):
         with r.wrap():
             pass
+
+
+
+def test_generatorexit_in_async_generator():
+    s = Synchronizer()
+
+    @s.asynccontextmanager
+    async def foo():
+        yield
+
+    async def main():
+        async with foo():
+            raise GeneratorExit()
+
+    with pytest.raises(GeneratorExit):
+        asyncio.run(main())
+


### PR DESCRIPTION
Some wacky combinations of Generators + async contextmanagers could previously cause some issues. This seems to fix it. Added a test that failed before this patch on Python 3.7.6, but now works, so pretty confident that this will work :man_shrugging: 