### PR TITLE
Fix the deadlock detection for gevent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install . pytest pytest-asyncio
+        run: pip install . pytest pytest-asyncio gevent
       - name: Run tests with pytest
         run: pytest -s

--- a/test/_gevent.py
+++ b/test/_gevent.py
@@ -1,0 +1,16 @@
+from gevent import monkey
+monkey.patch_all()
+
+import asyncio
+
+from synchronicity import Synchronizer, Interface
+
+async def f(x):
+    await asyncio.sleep(0.1)
+    return x**2
+
+
+s = Synchronizer()
+f_s = s.create(f)[Interface.BLOCKING]
+for i in range(3):
+    assert f_s(42) == 1764

--- a/test/gevent_test.py
+++ b/test/gevent_test.py
@@ -1,0 +1,10 @@
+import subprocess
+import os
+import sys
+
+
+def test_gevent():
+    # Run it in a separate process because gevent modifies a lot of modules
+    fn = os.path.join(os.path.dirname(__file__), "_gevent.py")
+    ret = subprocess.run([sys.executable, fn], stdout=sys.stdout, stderr=sys.stderr, timeout=5)
+    assert ret.returncode == 0


### PR DESCRIPTION
Something with gevent causes asyncio to leak the event loop across threads – I think it's because it disables the C implementation and reverts to the native Python implementation, and the latter seems to not be thread-aware – it just looks at pids.

