### PR TITLE
Remove AUTODETECT

### DIFF
--- a/synchronicity/async_wrap.py
+++ b/synchronicity/async_wrap.py
@@ -15,6 +15,7 @@ def async_compat_wraps(func):
     Note: Does not forward async generator information other than explicit annotations
     """
     if inspect.iscoroutinefunction(func):
+
         def asyncfunc_deco(user_wrapper):
             @functools.wraps(func)
             async def wrapper(*args, **kwargs):
@@ -24,6 +25,7 @@ def async_compat_wraps(func):
                     raise uc_exc.exc from None
 
             return wrapper
+
         return asyncfunc_deco
 
     return functools.wraps(func)

--- a/synchronicity/async_wrap.py
+++ b/synchronicity/async_wrap.py
@@ -1,7 +1,8 @@
 import functools
 import inspect
 
-from synchronicity import Interface
+from .exceptions import UserCodeException
+from .interface import Interface
 
 
 def async_compat_wraps(func):
@@ -17,7 +18,10 @@ def async_compat_wraps(func):
         def asyncfunc_deco(user_wrapper):
             @functools.wraps(func)
             async def wrapper(*args, **kwargs):
-                return await user_wrapper(*args, **kwargs)
+                try:
+                    return await user_wrapper(*args, **kwargs)
+                except UserCodeException as uc_exc:
+                    raise uc_exc.exc from None
 
             return wrapper
         return asyncfunc_deco

--- a/synchronicity/callback.py
+++ b/synchronicity/callback.py
@@ -6,6 +6,7 @@ class Callback:
     """A callback is when synchronized call needs to call outside functions passed into it.
 
     Currently only supports non-generator functions."""
+
     def __init__(self, synchronizer, f, interface):
         self._synchronizer = synchronizer
         self._interface = interface

--- a/synchronicity/interface.py
+++ b/synchronicity/interface.py
@@ -2,6 +2,5 @@ import enum
 
 
 class Interface(enum.Enum):
-    AUTODETECT = enum.auto()
     BLOCKING = enum.auto()
     ASYNC = enum.auto()

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -344,13 +344,11 @@ class Synchronizer:
                 else:
                     return res
             elif is_coroutine:
-                # The run_function_* may throw UserCodeExceptions that
-                # need to be unwrapped here at the entrypoint
                 if interface == Interface.ASYNC:
                     coro = self._run_function_async(res, interface)
-                    coro = unwrap_coro_exception(coro)
                     return coro
                 elif interface == Interface.BLOCKING:
+                    # This is the entrypoint, so we need to unwrap the exception here
                     try:
                         return self._run_function_sync(res, interface)
                     except UserCodeException as uc_exc:

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -95,6 +95,7 @@ class Synchronizer:
                 return self._loop
 
             is_ready = threading.Event()
+
             def thread_inner():
                 async def loop_inner():
                     self._loop = asyncio.get_running_loop()
@@ -310,7 +311,9 @@ class Synchronizer:
             f_wrapped.__name__ = name
             f_wrapped.__qualname__ = name
 
-    def _wrap_callable(self, f, interface, name=None, allow_futures=True, unwrap_user_excs=True):
+    def _wrap_callable(
+        self, f, interface, name=None, allow_futures=True, unwrap_user_excs=True
+    ):
         if hasattr(f, self._original_attr):
             if self._multiwrap_warning:
                 warnings.warn(
@@ -386,7 +389,9 @@ class Synchronizer:
         return f_wrapped
 
     def _wrap_proxy_method(self, method, interface, allow_futures=True):
-        method = self._wrap_callable(method, interface, allow_futures=allow_futures, unwrap_user_excs=False)
+        method = self._wrap_callable(
+            method, interface, allow_futures=allow_futures, unwrap_user_excs=False
+        )
 
         @wraps_by_interface(interface, method)
         def proxy_method(wrapped_self, *args, **kwargs):
@@ -504,7 +509,7 @@ class Synchronizer:
         warnings.warn(
             "No need to use Synchronizer.asynccontextmanager,"
             "can just use contextlib.asynccontextmanager instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
         return contextlib.asynccontextmanager(func)
 

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -22,14 +22,12 @@ _RETURN_FUTURE_KWARG = "_future"
 
 # Default names for classes
 _CLASS_PREFIXES = {
-    Interface.AUTODETECT: "Auto",
     Interface.BLOCKING: "Blocking",
     Interface.ASYNC: "Async",
 }
 
 # Default names for functions
 _FUNCTION_PREFIXES = {
-    Interface.AUTODETECT: "auto_",
     Interface.BLOCKING: "blocking_",
     Interface.ASYNC: "async_",
 }
@@ -140,15 +138,6 @@ class Synchronizer:
             return False
         current_loop = self._get_running_loop()
         return loop == current_loop
-
-    def _get_runtime_interface(self, interface):
-        """Returns one out of Interface.ASYNC or Interface.BLOCKING"""
-        if interface == Interface.AUTODETECT:
-            # TODO: delete this method
-            return Interface.ASYNC if self._get_running_loop() else Interface.BLOCKING
-        else:
-            assert interface in (Interface.ASYNC, Interface.BLOCKING)
-            return interface
 
     def _wrap_check_async_leakage(self, coro):
         """Check if a coroutine returns another coroutine (or an async generator) and warn.
@@ -344,7 +333,6 @@ class Synchronizer:
             # Figure out if this is a coroutine or something
             is_coroutine = inspect.iscoroutine(res)
             is_asyncgen = inspect.isasyncgen(res)
-            runtime_interface = self._get_runtime_interface(interface)
 
             if return_future:
                 if not allow_futures:
@@ -358,11 +346,11 @@ class Synchronizer:
             elif is_coroutine:
                 # The run_function_* may throw UserCodeExceptions that
                 # need to be unwrapped here at the entrypoint
-                if runtime_interface == Interface.ASYNC:
+                if interface == Interface.ASYNC:
                     coro = self._run_function_async(res, interface)
                     coro = unwrap_coro_exception(coro)
                     return coro
-                elif runtime_interface == Interface.BLOCKING:
+                elif interface == Interface.BLOCKING:
                     try:
                         return self._run_function_sync(res, interface)
                     except UserCodeException as uc_exc:
@@ -374,9 +362,9 @@ class Synchronizer:
             elif is_asyncgen:
                 # Note that the _run_generator_* functions handle their own
                 # unwrapping of exceptions (this happens during yielding)
-                if runtime_interface == Interface.ASYNC:
+                if interface == Interface.ASYNC:
                     return self._run_generator_async(res, interface)
-                elif runtime_interface == Interface.BLOCKING:
+                elif interface == Interface.BLOCKING:
                     return self._run_generator_sync(res, interface)
             else:
                 if inspect.isfunction(res) or isinstance(
@@ -465,11 +453,11 @@ class Synchronizer:
         for k, v in cls.__dict__.items():
             if k in _BUILTIN_ASYNC_METHODS:
                 k_sync = _BUILTIN_ASYNC_METHODS[k]
-                if interface in (Interface.BLOCKING, Interface.AUTODETECT):
+                if interface == Interface.BLOCKING:
                     new_dict[k_sync] = self._wrap_proxy_method(
                         v, interface, allow_futures=False
                     )
-                if interface in (Interface.ASYNC, Interface.AUTODETECT):
+                if interface == Interface.ASYNC:
                     new_dict[k] = self._wrap_proxy_method(
                         v, interface, allow_futures=False
                     )
@@ -524,7 +512,10 @@ class Synchronizer:
 
     # New interface that (almost) doesn't mutate objects
 
-    def create(self, object):  # TODO: this should really be __call__ later
+    def create(self, object):
+        # TODO(erikbern): make this one take the interface as an argument,
+        # instead of returning a dict
+        # TODO(erikbern): make this one take the new class name as an argument
         if inspect.isclass(object) or inspect.isfunction(object):
             # This is a class/function, for which we cache the interfaces
             interfaces = {}
@@ -542,14 +533,14 @@ class Synchronizer:
             )
         return interfaces
 
+    def create_blocking(self, object):
+        return self.create(object)[Interface.BLOCKING]
+
+    def create_async(self, object):
+        return self.create(object)[Interface.ASYNC]
+
     def is_synchronized(self, object):
         if inspect.isclass(object) or inspect.isfunction(object):
             return hasattr(object, self._original_attr)
         else:
             return hasattr(object.__class__, self._original_attr)
-
-    # Old interface that we should consider purging
-
-    def __call__(self, object):
-        interfaces = self.create(object)
-        return interfaces[Interface.AUTODETECT]

--- a/test/_gevent.py
+++ b/test/_gevent.py
@@ -3,7 +3,7 @@ monkey.patch_all()
 
 import asyncio
 
-from synchronicity import Synchronizer, Interface
+from synchronicity import Synchronizer
 
 async def f(x):
     await asyncio.sleep(0.1)
@@ -11,6 +11,6 @@ async def f(x):
 
 
 s = Synchronizer()
-f_s = s.create(f)[Interface.BLOCKING]
+f_s = s.create_blocking(f)
 for i in range(3):
     assert f_s(42) == 1764

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -18,6 +18,6 @@ async def run():
 s = Synchronizer()
 
 try:
-    s(run)()
+    s.create_blocking(run)()
 except KeyboardInterrupt:
     pass

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -44,7 +44,7 @@ class Resource:
 
 
 def test_asynccontextmanager_sync():
-    r = s(Resource)()
+    r = s.create_blocking(Resource)()
     assert r.get_state() == "none"
     with r.wrap():
         assert r.get_state() == "entered"
@@ -53,7 +53,7 @@ def test_asynccontextmanager_sync():
 
 @pytest.mark.asyncio
 async def test_asynccontextmanager_async():
-    r = s(Resource)()
+    r = s.create_async(Resource)()
     assert r.get_state() == "none"
     async with r.wrap():
         assert r.get_state() == "entered"
@@ -62,7 +62,7 @@ async def test_asynccontextmanager_async():
 
 @pytest.mark.asyncio
 async def test_asynccontextmanager_async_raise():
-    r = s(Resource)()
+    r = s.create_async(Resource)()
     assert r.get_state() == "none"
     with pytest.raises(Exception):
         async with r.wrap():
@@ -73,7 +73,7 @@ async def test_asynccontextmanager_async_raise():
 
 @pytest.mark.asyncio
 async def test_asynccontextmanager_yield_twice():
-    r = s(Resource)()
+    r = s.create_async(Resource)()
     with pytest.raises(RuntimeError):
         async with r.wrap_yield_twice():
             pass
@@ -81,7 +81,7 @@ async def test_asynccontextmanager_yield_twice():
 
 @pytest.mark.asyncio
 async def test_asynccontextmanager_never_yield():
-    r = s(Resource)()
+    r = s.create_async(Resource)()
     with pytest.raises(RuntimeError):
         async with r.wrap_never_yield():
             pass
@@ -92,7 +92,7 @@ async def test_asynccontextmanager_nested():
     s = Synchronizer()
     finally_blocks = []
 
-    @s
+    @s.create_async
     @asynccontextmanager
     async def a():
         try:
@@ -100,7 +100,7 @@ async def test_asynccontextmanager_nested():
         finally:
             finally_blocks.append("A")
 
-    @s
+    @s.create_async
     @asynccontextmanager
     async def b():
         async with a() as it:
@@ -119,7 +119,7 @@ async def test_asynccontextmanager_nested():
 @pytest.mark.skip(reason="This one will be much easier to fix once AUTODETECT is gone")
 @pytest.mark.asyncio
 async def test_asynccontextmanager_with_in_async():
-    r = s(Resource)()
+    r = s.create_async(Resource)()
     with pytest.raises(RuntimeError):
         with r.wrap():
             pass

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -116,11 +116,10 @@ async def test_asynccontextmanager_nested():
     assert finally_blocks == ["B", "A"]
 
 
-@pytest.mark.skip(reason="This one will be much easier to fix once AUTODETECT is gone")
 @pytest.mark.asyncio
 async def test_asynccontextmanager_with_in_async():
     r = s.create_async(Resource)()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AttributeError):
         with r.wrap():
             pass
 

--- a/test/pickle_test.py
+++ b/test/pickle_test.py
@@ -1,13 +1,9 @@
 import pickle
 import pytest
 
-from synchronicity import Synchronizer
+from synchronicity import Interface, Synchronizer
 
 
-s = Synchronizer()
-
-
-@s
 class PicklableClass:
     async def f(self, x):
         return x**2
@@ -15,7 +11,9 @@ class PicklableClass:
 
 @pytest.mark.skip(reason="Let's revisit this in 0.2.0")
 def test_pickle():
-    obj = PicklableClass()
+    s = Synchronizer()
+    BlockingPicklableClass = s.create(PicklableClass, Interface.BLOCKING)
+    obj = BlockingPicklableClass()
     assert obj.f(42) == 1764
     data = pickle.dumps(obj)
     obj2 = pickle.loads(data)
@@ -23,4 +21,5 @@ def test_pickle():
 
 
 def test_pickle_synchronizer():
+    s = Synchronizer()
     pickle.dumps(s)

--- a/test/threading_test.py
+++ b/test/threading_test.py
@@ -24,7 +24,7 @@ async def f(i):
 def test_multithreaded(n_threads=20):
     s = Synchronizer()
 
-    f_s = s(f)
+    f_s = s.create_blocking(f)
 
     t0 = time.time()
     with concurrent.futures.ThreadPoolExecutor(max_workers=n_threads) as executor:

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -37,7 +37,7 @@ def check_traceback(exc):
 
 def test_sync_to_async():
     s = Synchronizer()
-    f_s = s(f)
+    f_s = s.create_blocking(f)
     with pytest.raises(CustomException) as excinfo:
         f_s()
     check_traceback(excinfo.value)
@@ -45,7 +45,7 @@ def test_sync_to_async():
 
 def test_sync_to_async():
     s = Synchronizer()
-    f_baseexc_s = s(f_baseexc)
+    f_baseexc_s = s.create_blocking(f_baseexc)
     with pytest.raises(BaseException) as excinfo:
         f_s()
     check_traceback(excinfo.value)
@@ -54,7 +54,7 @@ def test_sync_to_async():
 @pytest.mark.asyncio
 async def test_async_to_async():
     s = Synchronizer()
-    f_s = s(f)
+    f_s = s.create_async(f)
     with pytest.raises(CustomException) as excinfo:
         await f_s()
     check_traceback(excinfo.value)
@@ -62,7 +62,7 @@ async def test_async_to_async():
 
 def test_sync_to_async_gen():
     s = Synchronizer()
-    gen_s = s(gen)
+    gen_s = s.create_blocking(gen)
     with pytest.raises(CustomException) as excinfo:
         for x in gen_s():
             pass
@@ -72,7 +72,7 @@ def test_sync_to_async_gen():
 @pytest.mark.asyncio
 async def test_async_to_async_gen():
     s = Synchronizer()
-    gen_s = s(gen)
+    gen_s = s.create_async(gen)
     with pytest.raises(CustomException) as excinfo:
         async for x in gen_s():
             pass
@@ -82,7 +82,7 @@ async def test_async_to_async_gen():
 @pytest.mark.skip(reason="This one will be much easier to fix once AUTODETECT is gone")
 def test_sync_to_async_ctx_mgr():
     s = Synchronizer()
-    ctx_mgr = s(s.asynccontextmanager(gen))
+    ctx_mgr = s.create_blocking(s.asynccontextmanager(gen))
     with pytest.raises(CustomException) as excinfo:
         with ctx_mgr():
             pass
@@ -93,7 +93,7 @@ def test_sync_to_async_ctx_mgr():
 @pytest.mark.asyncio
 async def test_async_to_async_ctx_mgr():
     s = Synchronizer()
-    ctx_mgr = s(s.asynccontextmanager(gen))
+    ctx_mgr = s.create_async(s.asynccontextmanager(gen))
     with pytest.raises(CustomException) as excinfo:
         async with ctx_mgr():
             pass
@@ -110,6 +110,6 @@ def test_recursive():
             return await f(n - 1)
 
     with pytest.raises(CustomException) as excinfo:
-        f_blocking = s.create(f)[Interface.BLOCKING]
+        f_blocking = s.create_blocking(f)
         f_blocking(10)
     check_traceback(excinfo.value)

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -10,19 +10,19 @@ def f(x):
 
 def test_multiwrap_warning(recwarn):
     s = Synchronizer(multiwrap_warning=True)
-    f_s = s(f)
+    f_s = s.create_blocking(f)
     assert f_s(42) == 1764
     assert len(recwarn) == 0
-    f_s_s = s(f_s)
+    f_s_s = s.create_blocking(f_s)
     assert f_s_s(42) == 1764
     assert len(recwarn) == 1
 
 
 def test_multiwrap_no_warning(recwarn):
     s = Synchronizer()
-    f_s = s(f)
+    f_s = s.create_blocking(f)
     assert f_s(42) == 1764
-    f_s_s = s(f_s)
+    f_s_s = s.create_blocking(f_s)
     assert f_s_s(42) == 1764
     assert len(recwarn) == 0
 
@@ -38,6 +38,6 @@ async def returns_asyncgen():
 def test_check_double_wrapped(recwarn):
     s = Synchronizer()
     assert len(recwarn) == 0
-    ret = s(returns_asyncgen)()
+    ret = s.create_blocking(returns_asyncgen)()
     assert inspect.isasyncgen(ret)
     assert len(recwarn) == 1


### PR DESCRIPTION
This removes the AUTODETECT feature, which we don't use at Modal, and I think is also dangerous because it doesn't always work. Once this is merged, I'm planning to roll this into 0.3.0

The main drawback of this is that it breaks using the synchronizer as a decorator, since we require the interface as a second argument. We don't use that in the modal-client, and I tend to think it was a bad idea because of the risk it creates