### PR TITLE
Don't wrap `CancelledError`s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7.9", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Python ${{ matrix.python-version }}

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -97,19 +97,12 @@ class Synchronizer:
                 return self._loop
 
             is_ready = threading.Event()
-
             def thread_inner():
                 async def loop_inner():
                     self._loop = asyncio.get_running_loop()
                     self._stopping = asyncio.Event()
                     is_ready.set()
                     await self._stopping.wait()  # wait until told to stop
-                    # mute asyncio errors that appear during tear down of
-                    # the event loop
-                    # Otherwise it's common to get RuntimeErrors if
-                    # threadpool executors get shut down before tasks
-                    # using them are done running
-                    self._loop.set_exception_handler(lambda a, b: None)
 
                 asyncio.run(loop_inner())
 

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -104,6 +104,12 @@ class Synchronizer:
                     self._stopping = asyncio.Event()
                     is_ready.set()
                     await self._stopping.wait()  # wait until told to stop
+                    # mute asyncio errors that appear during tear down of
+                    # the event loop
+                    # Otherwise it's common to get RuntimeErrors if
+                    # threadpool executors get shut down before tasks
+                    # using them are done running
+                    self._loop.set_exception_handler(lambda a, b: None)
 
                 asyncio.run(loop_inner())
 

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -6,6 +6,9 @@ async def run():
         while True:
             print("running")
             await asyncio.sleep(0.3)
+    except asyncio.CancelledError:
+        print("cancelled")
+        raise
     finally:
         print("stopping")
         await asyncio.sleep(0.1)
@@ -13,4 +16,8 @@ async def run():
 
 
 s = Synchronizer()
-s(run)()
+
+try:
+    s(run)()
+except KeyboardInterrupt:
+    pass

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -11,11 +11,14 @@ def test_shutdown():
     p = subprocess.Popen(
         [sys.executable, fn],
         stdout=subprocess.PIPE,
-        stderr=sys.stderr,
+        stderr=subprocess.PIPE,
         env={"PYTHONUNBUFFERED": "1"},
     )
     for i in range(3):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == b"running\n"
     p.send_signal(signal.SIGINT)
+    assert p.stdout.readline() == b"cancelled\n"
     assert p.stdout.readline() == b"stopping\n"
     assert p.stdout.readline() == b"exiting\n"
+    stderr_content = p.stderr.read()
+    assert b"Traceback" not in stderr_content


### PR DESCRIPTION
~~Haven't been able to make a simple reproduction of the issue, but I've seen issues where RuntimeErrors are printed during teardown when new threadpool executor tasks are attempted to be scheduled after the executor has shut down~~

Found a better reproduction which seems to pinpoint the problem better. See last comment below. Basically since we were wrapping CancelledErrors, tasks were not treated as cancelled by asyncio and that causes asyncio to spam tracebacks on event loop teardown.