### PR TITLE
Restrict Python version to >=3.7.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7.9", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [options]
 packages = find:
+python_requires = >=3.7.9


### PR DESCRIPTION
3.7.8 and earlier has a bug in the asynccontextmanager implementation which was previously fixed using the vendored version of contextlib, but since that has been removed it would be good to enforce this version so people don't accidentally install it on a broken Python version