### PR TITLE
Change the interface of `.create`

### DIFF
--- a/test/_gevent.py
+++ b/test/_gevent.py
@@ -1,9 +1,11 @@
 from gevent import monkey
+
 monkey.patch_all()
 
 import asyncio
 
 from synchronicity import Synchronizer
+
 
 async def f(x):
     await asyncio.sleep(0.1)

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -1,6 +1,7 @@
 import asyncio
 from synchronicity import Synchronizer
 
+
 async def run():
     try:
         while True:

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -124,7 +124,6 @@ async def test_asynccontextmanager_with_in_async():
             pass
 
 
-
 def test_generatorexit_in_async_generator():
     s = Synchronizer()
 
@@ -138,4 +137,3 @@ def test_generatorexit_in_async_generator():
 
     with pytest.raises(GeneratorExit):
         asyncio.run(main())
-

--- a/test/callback_test.py
+++ b/test/callback_test.py
@@ -48,7 +48,7 @@ async def test_translate():
         def get(self):
             return self.x
 
-    BlockingFoo = s.create(Foo)[Interface.BLOCKING]
+    BlockingFoo = s.create_blocking(Foo)
 
     def f(foo):
         assert isinstance(foo, BlockingFoo)

--- a/test/docstring_test.py
+++ b/test/docstring_test.py
@@ -20,12 +20,12 @@ def test_docs():
     assert foo.__init__.__doc__ == "init docs"
     assert foo.bar.__doc__ == "bar docs"
 
-    BlockingFoo = s.create(Foo)[Interface.BLOCKING]
+    BlockingFoo = s.create_blocking(Foo)
     blocking_foo = BlockingFoo()
     assert blocking_foo.__init__.__doc__ == "init docs"
     assert blocking_foo.bar.__doc__ == "bar docs"
 
-    AsyncFoo = s.create(Foo)[Interface.ASYNC]
+    AsyncFoo = s.create_async(Foo)
     async_foo = AsyncFoo()
     assert async_foo.__init__.__doc__ == "init docs"
     assert async_foo.bar.__doc__ == "bar docs"

--- a/test/generators_test.py
+++ b/test/generators_test.py
@@ -5,6 +5,7 @@ from synchronicity import Synchronizer, Interface
 
 events = []
 
+
 async def async_producer():
     for i in range(10):
         events.append("producer")

--- a/test/getattr_test.py
+++ b/test/getattr_test.py
@@ -40,7 +40,7 @@ def test_getattr():
         asyncio.run(foo.y)
     assert foo.z == 42
 
-    BlockingFoo = s.create(Foo)[Interface.BLOCKING]
+    BlockingFoo = s.create_blocking(Foo)
 
     blocking_foo = BlockingFoo()
     blocking_foo.x = 42
@@ -52,7 +52,7 @@ def test_getattr():
     blocking_foo = BlockingFoo.make_foo()
     assert isinstance(blocking_foo, BlockingFoo)
 
-    AsyncFoo = s.create(Foo)[Interface.ASYNC]
+    AsyncFoo = s.create_async(Foo)
     async_foo = AsyncFoo()
     async_foo.x = 42
     assert asyncio.run(async_foo.x) == 42

--- a/test/gevent_test.py
+++ b/test/gevent_test.py
@@ -6,5 +6,7 @@ import sys
 def test_gevent():
     # Run it in a separate process because gevent modifies a lot of modules
     fn = os.path.join(os.path.dirname(__file__), "_gevent.py")
-    ret = subprocess.run([sys.executable, fn], stdout=sys.stdout, stderr=sys.stderr, timeout=5)
+    ret = subprocess.run(
+        [sys.executable, fn], stdout=sys.stdout, stderr=sys.stderr, timeout=5
+    )
     assert ret.returncode == 0

--- a/test/helper_methods_test.py
+++ b/test/helper_methods_test.py
@@ -10,6 +10,6 @@ def test_is_synchronized():
     class Foo:
         pass
 
-    BlockingFoo = s.create(Foo)[Interface.BLOCKING]
+    BlockingFoo = s.create_blocking(Foo)
     assert s.is_synchronized(Foo) == False
     assert s.is_synchronized(BlockingFoo) == True

--- a/test/inspect_test.py
+++ b/test/inspect_test.py
@@ -13,10 +13,8 @@ class _Api:
 
 def test_inspect_coroutinefunction():
     s = Synchronizer()
-    interfaces = s.create(_Api)
-
-    BlockingApi = interfaces[Interface.BLOCKING]
-    AioApi = interfaces[Interface.ASYNC]
+    BlockingApi = s.create_blocking(_Api)
+    AioApi = s.create_async(_Api)
 
     assert inspect.iscoroutinefunction(BlockingApi.blocking_func) == False
     assert inspect.iscoroutinefunction(BlockingApi.async_func) == False

--- a/test/mark_test.py
+++ b/test/mark_test.py
@@ -7,5 +7,5 @@ def test_function_sync():
     async def f(x):
         return x**2
 
-    f_blocking = s.create(f)[Interface.BLOCKING]
+    f_blocking = s.create_blocking(f)
     assert f_blocking(42) == 1764

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -395,8 +395,9 @@ async def test_class_async_back_and_forth():
     ret = await fut
     assert ret == 1764
 
-
     # The problem here is that f is already synchronized by another synchronizer, which shouldn't be allowed
+
+
 @pytest.mark.skip(
     reason="Skip this until we've made it impossible to re-synchronize objects"
 )
@@ -423,7 +424,6 @@ def test_event_loop():
         s._start_loop(new_loop)
 
 
-
 @pytest.mark.parametrize("interface_type", [Interface.BLOCKING, Interface.ASYNC])
 def test_doc_transfer(interface_type):
     class Foo:
@@ -433,8 +433,20 @@ def test_doc_transfer(interface_type):
             """hello"""
 
     s = Synchronizer()
-    output_class = s.create(Foo)[interface_type]
+    output_class = s.create(Foo, interface_type)
 
     assert output_class.__doc__ == "Hello"
     assert output_class.foo.__doc__ == "hello"
 
+
+def test_set_function_name():
+    s = Synchronizer()
+    f_s = s.create_blocking(f, "xyz")
+    assert f_s(42) == 1764
+    assert f_s.__name__ == "xyz"
+
+
+def test_set_class_name():
+    s = Synchronizer()
+    BlockingMyClass = s.create_blocking(MyClass, "XYZClass")
+    assert BlockingMyClass.__name__ == "XYZClass"

--- a/test/translate_test.py
+++ b/test/translate_test.py
@@ -40,9 +40,9 @@ def test_translate():
         def cls_out(cls):
             return FooProvider
 
-    BlockingFoo = s.create(Foo)[Interface.BLOCKING]
+    BlockingFoo = s.create(Foo, Interface.BLOCKING)
     assert BlockingFoo.__name__ == "BlockingFoo"
-    BlockingFooProvider = s.create(FooProvider)[Interface.BLOCKING]
+    BlockingFooProvider = s.create(FooProvider, Interface.BLOCKING)
     assert BlockingFooProvider.__name__ == "BlockingFooProvider"
     foo_provider = BlockingFooProvider()
 


### PR DESCRIPTION
Takes an interface enum now as well.

This is a much smaller PR once rebased on #70 