### PR TITLE
remove the async context manager

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -509,14 +509,6 @@ class Synchronizer:
         interfaces[interface] = new_obj
         return new_obj
 
-    def asynccontextmanager(self, func):
-        warnings.warn(
-            "No need to use Synchronizer.asynccontextmanager,"
-            "can just use contextlib.asynccontextmanager instead.",
-            DeprecationWarning,
-        )
-        return contextlib.asynccontextmanager(func)
-
     # New interface that (almost) doesn't mutate objects
 
     def create_blocking(self, obj, name = None):

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -121,20 +121,3 @@ async def test_asynccontextmanager_with_in_async():
     with pytest.raises(AttributeError):
         with r.wrap():
             pass
-
-
-
-def test_generatorexit_in_async_generator():
-    s = Synchronizer()
-
-    @s.asynccontextmanager
-    async def foo():
-        yield
-
-    async def main():
-        async with foo():
-            raise GeneratorExit()
-
-    with pytest.raises(GeneratorExit):
-        asyncio.run(main())
-


### PR DESCRIPTION
Can use the built-in one instead