### PR TITLE
bump version and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ from synchronicity import Synchronizer
 
 synchronizer = Synchronizer()
 
-@synchronizer
+@synchronizer.create_blocking
 async def f(x):
     await asyncio.sleep(1.0)
     return x**2
@@ -85,7 +85,7 @@ Generators
 The decorator also works on generators:
 
 ```python
-@synchronizer
+@synchronizer.create_blocking
 async def f(n):
     for i in range(n):
         await asyncio.sleep(1.0)
@@ -105,7 +105,7 @@ It also operates on classes by wrapping every method on the class:
 
 
 ```python
-@synchronizer
+@synchronizer.create_blocking
 class DBConnection:
     def __init__(self, url):
         self._url = url
@@ -133,7 +133,7 @@ from synchronicity import Synchronizer
 
 synchronizer = Synchronizer()
 
-@synchronizer
+@synchronizer.create_blocking
 async def f(x):
     await asyncio.sleep(1.0)
     return x**2

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="synchronicity", version="0.2.14")
+setup(name="synchronicity", version="0.3.0")


### PR DESCRIPTION
0.3.0 gets rid of the autodetect behavior and the `__call__` method on the synchronizer – making it explicit what interface you want.

We probably won't be on 0.3.* very long – we're planning to rewrite synchronicity a bit more so that it operates on annotations and does it statically.