### PR TITLE
Fix exception unwrapping

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -343,6 +343,7 @@ class Synchronizer:
             elif is_coroutine:
                 if interface == Interface.ASYNC:
                     coro = self._run_function_async(res, interface)
+                    coro = unwrap_coro_exception(coro)
                     return coro
                 elif interface == Interface.BLOCKING:
                     # This is the entrypoint, so we need to unwrap the exception here

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -315,6 +315,8 @@ class Synchronizer:
         if name is None:
             name = _FUNCTION_PREFIXES[interface] + f.__name__
 
+        is_coroutinefunction = inspect.iscoroutinefunction(f)
+
         @wraps_by_interface(interface, f)
         def f_wrapped(*args, **kwargs):
             return_future = kwargs.pop(_RETURN_FUTURE_KWARG, False)
@@ -343,10 +345,15 @@ class Synchronizer:
             elif is_coroutine:
                 if interface == Interface.ASYNC:
                     coro = self._run_function_async(res, interface)
-                    coro = unwrap_coro_exception(coro)
+                    if not is_coroutinefunction:
+                        # If this is a non-async function that returns a coroutine,
+                        # then this is the exit point, and we need to unwrap any
+                        # wrapped exception here. Otherwise, the exit point is
+                        # in async_wrap.py
+                        coro = unwrap_coro_exception(coro)
                     return coro
                 elif interface == Interface.BLOCKING:
-                    # This is the entrypoint, so we need to unwrap the exception here
+                    # This is the exit point, so we need to unwrap the exception here
                     try:
                         return self._run_function_sync(res, interface)
                     except UserCodeException as uc_exc:
@@ -444,7 +451,9 @@ class Synchronizer:
 
     def _wrap_class(self, cls, interface, name):
         bases = tuple(
-            self._wrap(base, interface, require_already_wrapped=(name is not None)) if base != object else object
+            self._wrap(base, interface, require_already_wrapped=(name is not None))
+            if base != object
+            else object
             for base in cls.__bases__
         )
         new_dict = {self._original_attr: cls}
@@ -483,7 +492,7 @@ class Synchronizer:
         new_cls.__doc__ = cls.__doc__
         return new_cls
 
-    def _wrap(self, obj, interface, name = None, require_already_wrapped = False):
+    def _wrap(self, obj, interface, name=None, require_already_wrapped=False):
         # This method works for classes, functions, and instances
         # It wraps the object, and caches the wrapped object
 
@@ -507,7 +516,9 @@ class Synchronizer:
 
         if require_already_wrapped:
             # This happens if a class has a custom name but its base class doesn't
-            raise RuntimeError(f"{obj} needs to be serialized explicitly with a custom name")
+            raise RuntimeError(
+                f"{obj} needs to be serialized explicitly with a custom name"
+            )
 
         # Wrap object (different cases based on the type)
         if inspect.isclass(obj):
@@ -529,10 +540,10 @@ class Synchronizer:
 
     # New interface that (almost) doesn't mutate objects
 
-    def create_blocking(self, obj, name = None):
+    def create_blocking(self, obj, name=None):
         return self._wrap(obj, Interface.BLOCKING, name)
 
-    def create_async(self, obj, name = None):
+    def create_async(self, obj, name=None):
         return self._wrap(obj, Interface.ASYNC, name)
 
     def is_synchronized(self, obj):

--- a/test/_gevent.py
+++ b/test/_gevent.py
@@ -1,9 +1,11 @@
 from gevent import monkey
+
 monkey.patch_all()
 
 import asyncio
 
 from synchronicity import Synchronizer
+
 
 async def f(x):
     await asyncio.sleep(0.1)

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -1,6 +1,7 @@
 import asyncio
 from synchronicity import Synchronizer
 
+
 async def run():
     try:
         while True:

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -1,4 +1,3 @@
-import asyncio
 from contextlib import asynccontextmanager
 import pytest
 

--- a/test/docstring_test.py
+++ b/test/docstring_test.py
@@ -1,4 +1,3 @@
-
 from synchronicity import Synchronizer
 
 

--- a/test/exception_test.py
+++ b/test/exception_test.py
@@ -64,3 +64,20 @@ def test_function_raises_baseexc_sync():
         f_raises_baseexc_s = s.create_blocking(f_raises_baseexc)
         f_raises_baseexc_s()
     assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+
+
+def f_raises_syncwrap():
+    return f_raises()  # returns a coro
+
+
+@pytest.mark.asyncio
+async def test_function_raises_async_syncwrap():
+    s = Synchronizer()
+    t0 = time.time()
+    f_raises_syncwrap_s = s.create_async(f_raises_syncwrap)
+    coro = f_raises_syncwrap_s()
+    assert inspect.iscoroutine(coro)
+    assert time.time() - t0 < SLEEP_DELAY
+    with pytest.raises(CustomException):
+        await coro
+    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY

--- a/test/exception_test.py
+++ b/test/exception_test.py
@@ -1,0 +1,66 @@
+import asyncio
+import concurrent
+import inspect
+import pytest
+import time
+
+from synchronicity import Synchronizer
+
+SLEEP_DELAY = 0.1
+
+
+class CustomException(Exception):
+    pass
+
+
+async def f_raises():
+    await asyncio.sleep(0.1)
+    raise CustomException("something failed")
+
+
+def test_function_raises_sync():
+    s = Synchronizer()
+    t0 = time.time()
+    with pytest.raises(CustomException):
+        f_raises_s = s.create_blocking(f_raises)
+        f_raises_s()
+    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+
+
+def test_function_raises_sync_futures():
+    s = Synchronizer()
+    t0 = time.time()
+    f_raises_s = s.create_blocking(f_raises)
+    fut = f_raises_s(_future=True)
+    assert isinstance(fut, concurrent.futures.Future)
+    assert time.time() - t0 < SLEEP_DELAY
+    with pytest.raises(CustomException):
+        fut.result()
+    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+
+
+@pytest.mark.asyncio
+async def test_function_raises_async():
+    s = Synchronizer()
+    t0 = time.time()
+    f_raises_s = s.create_async(f_raises)
+    coro = f_raises_s()
+    assert inspect.iscoroutine(coro)
+    assert time.time() - t0 < SLEEP_DELAY
+    with pytest.raises(CustomException):
+        await coro
+    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+
+
+async def f_raises_baseexc():
+    await asyncio.sleep(0.1)
+    raise KeyboardInterrupt
+
+
+def test_function_raises_baseexc_sync():
+    s = Synchronizer()
+    t0 = time.time()
+    with pytest.raises(BaseException):
+        f_raises_baseexc_s = s.create_blocking(f_raises_baseexc)
+        f_raises_baseexc_s()
+    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY

--- a/test/generators_test.py
+++ b/test/generators_test.py
@@ -5,6 +5,7 @@ from synchronicity import Synchronizer
 
 events = []
 
+
 async def async_producer():
     for i in range(10):
         events.append("producer")

--- a/test/gevent_test.py
+++ b/test/gevent_test.py
@@ -6,5 +6,7 @@ import sys
 def test_gevent():
     # Run it in a separate process because gevent modifies a lot of modules
     fn = os.path.join(os.path.dirname(__file__), "_gevent.py")
-    ret = subprocess.run([sys.executable, fn], stdout=sys.stdout, stderr=sys.stderr, timeout=5)
+    ret = subprocess.run(
+        [sys.executable, fn], stdout=sys.stdout, stderr=sys.stderr, timeout=5
+    )
     assert ret.returncode == 0

--- a/test/helper_methods_test.py
+++ b/test/helper_methods_test.py
@@ -1,4 +1,3 @@
-
 from synchronicity import Synchronizer
 
 

--- a/test/nowrap_test.py
+++ b/test/nowrap_test.py
@@ -5,11 +5,12 @@ from synchronicity import Synchronizer
 
 s = Synchronizer()
 
+
 @s.create_blocking
 class MyClass:
     async def f(self, x):
         await asyncio.sleep(0.2)
-        return x ** 2
+        return x**2
 
     @s.nowrap
     def g(self, x):

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -43,14 +43,6 @@ def test_sync_to_async():
     check_traceback(excinfo.value)
 
 
-def test_sync_to_async():
-    s = Synchronizer()
-    s.create_blocking(f_baseexc)
-    with pytest.raises(BaseException) as excinfo:
-        f_s()
-    check_traceback(excinfo.value)
-
-
 @pytest.mark.asyncio
 async def test_async_to_async():
     s = Synchronizer()

--- a/test/translate_test.py
+++ b/test/translate_test.py
@@ -1,4 +1,3 @@
-
 from synchronicity import Synchronizer
 
 


### PR DESCRIPTION
Accidentally broke this in #70 but it only showed up in kind of weird cases (the async interface, and only when calling a non-async function returning a coroutine raising an exception).

This fixes it. Will bump to 0.3.1 and release as well.