### PR TITLE
Adds translations of __annotations__ on classes and functions

### DIFF
--- a/synchronicity/async_wrap.py
+++ b/synchronicity/async_wrap.py
@@ -31,12 +31,10 @@ def type_compat_wraps(func, interface: Interface, new_annotations=None):
         return asyncfunc_deco
     else:
         def blockingfunc_deco(user_wrapper):
-            @functools.wraps(func)
-            def wrapper(*args, **kwargs):
-                return user_wrapper(*args, **kwargs)
+            wrapped = functools.wraps(func)(user_wrapper)
 
             if new_annotations:
-                wrapper.__annotations__ = new_annotations
+                wrapped.__annotations__ = new_annotations
 
-            return wrapper
+            return wrapped
         return blockingfunc_deco

--- a/synchronicity/async_wrap.py
+++ b/synchronicity/async_wrap.py
@@ -1,10 +1,12 @@
+import collections.abc
+import contextlib
 import functools
 import inspect
 import typing
 
 from .exceptions import UserCodeException
 from .interface import Interface
-
+from contextlib import asynccontextmanager as _asynccontextmanager
 
 def type_compat_wraps(func, interface: Interface, new_annotations=None):
     """Like functools.wraps but maintains `inspect.iscoroutinefunction` and allows custom type annotations overrides
@@ -38,3 +40,28 @@ def type_compat_wraps(func, interface: Interface, new_annotations=None):
 
             return wrapped
         return blockingfunc_deco
+
+
+
+
+YIELD_TYPE = typing.TypeVar("YIELD_TYPE")
+SEND_TYPE = typing.TypeVar("SEND_TYPE")
+
+def asynccontextmanager(f: typing.AsyncGenerator[YIELD_TYPE, SEND_TYPE]) -> typing.Callable[[], typing.AsyncContextManager[YIELD_TYPE]]:
+    """Wrapper around contextlib.asynccontextmanager that sets correct type annotations
+
+    The standard library one doesn't
+    """
+    acm_factory = _asynccontextmanager(f)
+
+    old_ret = acm_factory.__annotations__.pop("return", None)
+    if old_ret is not None:
+        if old_ret.__origin__ in [collections.abc.AsyncGenerator, collections.abc.AsyncIterator, collections.abc.AsyncIterator]:
+            acm_factory.__annotations__["return"] = typing.AsyncContextManager[old_ret.__args__[0]]
+        elif old_ret.__origin__ == contextlib.AbstractAsyncContextManager:
+            # if the standard lib fixes the annotations in the future, lets not break it...
+            return acm_factory
+    else:
+        raise ValueError("To use the fixed @asynccontextmanager, make sure to properly annotate your wrapped function as an AsyncGenerator")
+
+    return acm_factory

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -421,7 +421,7 @@ class Synchronizer:
 
     def _wrap_proxy_staticmethod(self, method, interface):
         method = self._wrap_callable(method.__func__, interface)
-        return staticmethod(method)
+        return staticmethod(self.wraps_by_interface(interface, method)(method))
 
     def _wrap_proxy_classmethod(self, method, interface):
         method = self._wrap_callable(method.__func__, interface)

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -605,6 +605,9 @@ class Synchronizer:
         if origin == collections.abc.Awaitable:
             return mapped_args[0]
 
+        if origin == collections.abc.Coroutine:
+            return mapped_args[2]
+
         return type_annotation.copy_with(mapped_args)
 
 

--- a/test/annotations_test.py
+++ b/test/annotations_test.py
@@ -25,6 +25,15 @@ class _Foo:
     def return_coroutine(self) -> typing.Coroutine[None, None, str]:
         pass
 
+    @classmethod
+    def some_classmethod(cls) -> typing.Awaitable[float]:
+        pass
+
+    @staticmethod
+    def some_staticmethod() -> typing.Awaitable[int]:
+        pass
+
+
 s = synchronicity.Synchronizer()
 BlockingBar = s.create_blocking(_Bar, "BlockingBar")
 AsyncBar = s.create_async(_Bar, "AsyncBar")
@@ -39,6 +48,8 @@ def test_wrapped_function_replaces_annotation():
     assert BlockingFoo.ctx.__annotations__["return"] == typing.ContextManager[int]
     assert BlockingFoo.return_awaitable.__annotations__["return"] == str
     assert BlockingFoo.return_coroutine.__annotations__["return"] == str
+    assert BlockingFoo.some_classmethod.__annotations__["return"] == float
+    assert BlockingFoo.some_staticmethod.__annotations__["return"] == int
 
 
 @pytest.mark.parametrize("t,interface,expected", [

--- a/test/annotations_test.py
+++ b/test/annotations_test.py
@@ -1,0 +1,45 @@
+import typing
+
+import pytest
+
+import synchronicity
+from synchronicity import Interface
+from synchronicity import async_wrap
+
+
+class _Bar:
+    pass
+
+class _Foo:
+    baz: _Bar
+    async def bar(self, arg1: typing.AsyncIterator[str]):
+        pass
+
+    @async_wrap.asynccontextmanager  # tests the annotations-compatible context manager factory
+    async def ctx(self) -> typing.AsyncGenerator[int, None]:
+        yield 0
+
+s = synchronicity.Synchronizer()
+BlockingBar = s.create_blocking(_Bar, "BlockingBar")
+AsyncBar = s.create_async(_Bar, "AsyncBar")
+BlockingFoo = s.create_blocking(_Foo, "BlockingFoo")
+AsyncFoo = s.create_async(_Foo, "AsyncFoo")
+
+@pytest.mark.parametrize("t,interface,expected", [
+    (typing.AsyncGenerator[int, str], Interface.BLOCKING, typing.Generator[int, str, None]),
+    (typing.AsyncContextManager[_Foo], Interface.BLOCKING, typing.ContextManager[BlockingFoo]),
+    (typing.AsyncContextManager[_Foo], Interface.ASYNC, typing.AsyncContextManager[AsyncFoo]),
+    (typing.Awaitable[typing.Awaitable[str]], Interface.ASYNC, typing.Awaitable[typing.Awaitable[str]]),
+    (typing.Awaitable[typing.Awaitable[str]], Interface.BLOCKING, str),
+    (typing.AsyncIterable[str], Interface.BLOCKING, typing.Iterable[str]),
+    (typing.AsyncIterator[str], Interface.BLOCKING, typing.Iterator[str]),
+])
+def test_annotation_mapping(t, interface, expected):
+    assert s._map_type_annotation(t, interface) == expected
+
+
+def test_wrapped_function_replaces_annotation():
+    assert BlockingFoo.bar.__annotations__["arg1"] == typing.Iterator[str]
+    assert BlockingFoo.__annotations__["baz"] == BlockingBar
+    assert AsyncFoo.ctx.__annotations__["return"] == typing.AsyncContextManager[int]
+    assert BlockingFoo.ctx.__annotations__["return"] == typing.ContextManager[int]

--- a/test/annotations_test.py
+++ b/test/annotations_test.py
@@ -33,6 +33,10 @@ class _Foo:
     def some_staticmethod() -> typing.Awaitable[int]:
         pass
 
+    async def some_async_gen(self) -> typing.AsyncGenerator[int, str]:
+        yield 1
+
+
 
 s = synchronicity.Synchronizer()
 BlockingBar = s.create_blocking(_Bar, "BlockingBar")
@@ -50,6 +54,7 @@ def test_wrapped_function_replaces_annotation():
     assert BlockingFoo.return_coroutine.__annotations__["return"] == str
     assert BlockingFoo.some_classmethod.__annotations__["return"] == float
     assert BlockingFoo.some_staticmethod.__annotations__["return"] == int
+    assert BlockingFoo.some_async_gen.__annotations__["return"] == typing.Generator[int, str, None]
 
 
 @pytest.mark.parametrize("t,interface,expected", [

--- a/test/async_wrap_test.py
+++ b/test/async_wrap_test.py
@@ -1,14 +1,16 @@
 import inspect
 import typing
 
-from synchronicity import async_wrap
+import synchronicity
+from synchronicity import async_wrap, Interface
 
+synchronizer = synchronicity.Synchronizer()
 
 def test_wrap_corofunc_using_async():
     async def foo():
         pass
 
-    @async_wrap.async_compat_wraps(foo)
+    @synchronizer.wraps_by_interface(Interface.ASYNC, foo)
     async def bar():
         pass
 
@@ -19,7 +21,7 @@ def test_wrap_corofunc_using_non_async():
     async def foo():
         pass
 
-    @async_wrap.async_compat_wraps(foo)
+    @synchronizer.wraps_by_interface(Interface.ASYNC, foo)
     def bar():
         pass
 
@@ -30,8 +32,9 @@ def test_wrap_annotated_asyncgen_using_async():
     async def foo() -> typing.AsyncGenerator[str, typing.Any]:
         yield "bar"
 
-    @async_wrap.async_compat_wraps(foo)
+    @synchronizer.wraps_by_interface(Interface.ASYNC, foo)
     async def bar():
         pass
 
+    # note that we do no explicit
     assert bar.__annotations__["return"] == typing.AsyncGenerator[str, typing.Any]


### PR DESCRIPTION
In followup work, we can use the translated annotations to emit type stubs for any translated entity, enabling static type checking