### PR TITLE
Handle backwards compatibility

### DIFF
--- a/synchronicity/interface.py
+++ b/synchronicity/interface.py
@@ -4,3 +4,4 @@ import enum
 class Interface(enum.Enum):
     BLOCKING = enum.auto()
     ASYNC = enum.auto()
+    AUTODETECT = enum.auto()  # DEPRECATED


### PR DESCRIPTION
Old modal-client versions don't pin the synchronicity version but expect the interface from 0.2 to remain.

0.3 broke a few things. The problem is if an old version is pinned and reinstalled – then it will install 0.3 and try to use it.

This introduces a backwards compatible interface as a stupid dumb fix. I'll leave it in place for about 3 months and will delete it later.