### PR TITLE
Migrate from setup.py to pyproject.toml build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+clean:
+	rm -rf build dist
+
+build: clean
+	pip wheel -w dist --no-deps .
+
+publish: build
+	twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "synchronicity"
+version = "0.4.3"
+description = "Export blocking and async library versions from a single async implementation"
+readme = "README.md"
+
+dependencies = [
+    "sigtools==4.0.1",
+]
+requires-python = ">=3.7.9"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["synchronicity*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[options]
-packages = find:
-python_requires = >=3.7.9
-
-install_requires =
-    sigtools==4.0.1

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="synchronicity", version="0.4.2")
+setup()


### PR DESCRIPTION
Not using pyproject.toml has started yielding warnings when installing the package on newer python installations.

I'm not super up to date with what best practices around packaging today dictates. I've used poetry before, but staying on setuptools as the builder seems like the path of least resistance for now?

This removes setup.py and setup.cfg in favor of using only pyproject.toml (with setuptools as the builder backend) and pip for building the package. Adds a convenience Makefile as well to make it easy to build and dist