### PR TITLE
Fix type stubs for wrapped context managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+venv
+*.egg-info

--- a/synchronicity/combined_types.py
+++ b/synchronicity/combined_types.py
@@ -3,7 +3,6 @@ from synchronicity.async_wrap import wraps_by_interface
 from synchronicity.exceptions import UserCodeException
 from synchronicity.interface import Interface
 import typing
-import typing_extensions
 
 if typing.TYPE_CHECKING:
     from synchronicity.synchronizer import Synchronizer
@@ -53,6 +52,7 @@ class MethodWithAio:
 
 
 CTX = typing.TypeVar("CTX", covariant=True)
+
 
 class AsyncAndBlockingContextManager(typing.Protocol[CTX]):
     def __enter__(self) -> CTX:

--- a/synchronicity/combined_types.py
+++ b/synchronicity/combined_types.py
@@ -1,4 +1,5 @@
 import functools
+import typing_extensions
 from synchronicity.async_wrap import wraps_by_interface
 from synchronicity.exceptions import UserCodeException
 from synchronicity.interface import Interface
@@ -54,7 +55,7 @@ class MethodWithAio:
 CTX = typing.TypeVar("CTX", covariant=True)
 
 
-class AsyncAndBlockingContextManager(typing.Protocol[CTX]):
+class AsyncAndBlockingContextManager(typing_extensions.Protocol[CTX]):
     def __enter__(self) -> CTX:
         ...
 

--- a/synchronicity/combined_types.py
+++ b/synchronicity/combined_types.py
@@ -1,0 +1,68 @@
+import functools
+from synchronicity.async_wrap import wraps_by_interface
+from synchronicity.exceptions import UserCodeException
+from synchronicity.interface import Interface
+import typing
+import typing_extensions
+
+if typing.TYPE_CHECKING:
+    from synchronicity.synchronizer import Synchronizer
+
+
+class FunctionWithAio:
+    def __init__(self, func, aio_func, synchronizer):
+        self._func = func
+        self._aio_func = self.aio = aio_func
+        self._synchronizer = synchronizer
+
+    def __call__(self, *args, **kwargs):
+        # .__call__ is special - it's being looked up on the class instead of the instance when calling something,
+        # so setting the magic method from the constructor is not possible
+        # https://stackoverflow.com/questions/22390532/object-is-not-callable-after-adding-call-method-to-instance
+        # so we need to use an explicit wrapper function here
+        try:
+            return self._func(*args, **kwargs)
+        except UserCodeException as uc_exc:
+            raise uc_exc.exc from None
+
+
+class MethodWithAio:
+    """Creates a bound method that can have callable child-properties on the method itself.
+
+    Child-properties are also bound to the parent instance.
+    """
+
+    def __init__(self, func, aio_func, synchronizer: "Synchronizer", is_classmethod=False):
+        self._func = func
+        self._aio_func = aio_func
+        self._synchronizer = synchronizer
+        self._is_classmethod = is_classmethod
+
+    def __get__(self, instance, owner=None):
+        bind_var = instance if instance and not self._is_classmethod else owner
+
+        bound_func = functools.wraps(self._func)(functools.partial(self._func, bind_var))  # bound blocking function
+        self._synchronizer._update_wrapper(bound_func, self._func, interface=Interface.BLOCKING)
+
+        bound_aio_func = wraps_by_interface(Interface._ASYNC_WITH_BLOCKING_TYPES, self._aio_func)(
+            functools.partial(self._aio_func, bind_var)
+        )  # bound async function
+        self._synchronizer._update_wrapper(bound_func, self._func, interface=Interface._ASYNC_WITH_BLOCKING_TYPES)
+        bound_func.aio = bound_aio_func
+        return bound_func
+
+
+CTX = typing.TypeVar("CTX", covariant=True)
+
+class AsyncAndBlockingContextManager(typing.Protocol[CTX]):
+    def __enter__(self) -> CTX:
+        ...
+
+    async def __aenter__(self) -> CTX:
+        ...
+
+    def __exit__(self, typ, value, tb):
+        ...
+
+    async def __aexit__(self, typ, value, tb):
+        ...

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -11,6 +11,7 @@ import warnings
 from typing import ForwardRef, Optional
 
 from synchronicity.annotations import evaluated_annotation
+from synchronicity.combined_types import MethodWithAio, FunctionWithAio
 
 from .async_wrap import wraps_by_interface
 from .callback import Callback
@@ -94,47 +95,7 @@ def should_have_aio_interface(func):
     return False
 
 
-class FunctionWithAio:
-    def __init__(self, func, aio_func, synchronizer):
-        self._func = func
-        self._aio_func = self.aio = aio_func
-        self._synchronizer = synchronizer
 
-    def __call__(self, *args, **kwargs):
-        # .__call__ is special - it's being looked up on the class instead of the instance when calling something,
-        # so setting the magic method from the constructor is not possible
-        # https://stackoverflow.com/questions/22390532/object-is-not-callable-after-adding-call-method-to-instance
-        # so we need to use an explicit wrapper function here
-        try:
-            return self._func(*args, **kwargs)
-        except UserCodeException as uc_exc:
-            raise uc_exc.exc from None
-
-
-class MethodWithAio:
-    """Creates a bound method that can have callable child-properties on the method itself.
-
-    Child-properties are also bound to the parent instance.
-    """
-
-    def __init__(self, func, aio_func, synchronizer: "Synchronizer", is_classmethod=False):
-        self._func = func
-        self._aio_func = aio_func
-        self._synchronizer = synchronizer
-        self._is_classmethod = is_classmethod
-
-    def __get__(self, instance, owner=None):
-        bind_var = instance if instance and not self._is_classmethod else owner
-
-        bound_func = functools.wraps(self._func)(functools.partial(self._func, bind_var))  # bound blocking function
-        self._synchronizer._update_wrapper(bound_func, self._func, interface=Interface.BLOCKING)
-
-        bound_aio_func = wraps_by_interface(Interface._ASYNC_WITH_BLOCKING_TYPES, self._aio_func)(
-            functools.partial(self._aio_func, bind_var)
-        )  # bound async function
-        self._synchronizer._update_wrapper(bound_func, self._func, interface=Interface._ASYNC_WITH_BLOCKING_TYPES)
-        bound_func.aio = bound_aio_func
-        return bound_func
 
 
 class Synchronizer:

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -95,9 +95,6 @@ def should_have_aio_interface(func):
     return False
 
 
-
-
-
 class Synchronizer:
     """Helps you offer a blocking (synchronous) interface to asynchronous code."""
 

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -22,6 +22,7 @@ from sigtools._signatures import EmptyAnnotation, UpgradedAnnotation, UpgradedPa
 
 import synchronicity
 from synchronicity import Interface, overload_tracking
+from synchronicity import combined_types
 from synchronicity.annotations import evaluated_annotation
 from synchronicity.synchronizer import (
     TARGET_INTERFACE_ATTR,
@@ -383,7 +384,7 @@ class StubEmitter:
                 return typing.Generator[mapped_args + (None,)]  # type: ignore
 
             if origin == contextlib.AbstractAsyncContextManager:
-                return typing.ContextManager[mapped_args]  # type: ignore
+                return combined_types.AsyncAndBlockingContextManager[mapped_args]  # type: ignore
 
             if origin == collections.abc.AsyncIterable:
                 return typing.Iterable[mapped_args]  # type: ignore

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -510,8 +510,12 @@ class StubEmitter:
         except Exception:
             raise Exception(f"Could not reformat generic {annotation.__origin__} with arguments {args}")
 
+        formatted_annotation = formatted_annotation.replace(
+            "typing.Abstract", "typing."
+        )  # fix for Python 3.7 formatting typing.AsyncContextManager as 'typing.AbstractContextManager' etc.
         # this is a bit ugly, but gets rid of incorrect module qualification of Generic subclasses:
         # TODO: find a better way...
+
         if formatted_annotation.startswith(self.target_module + "."):
             return formatted_annotation.split(self.target_module + ".", 1)[1]
         return formatted_annotation

--- a/test/type_stub_helpers/e2e_example_export.py
+++ b/test/type_stub_helpers/e2e_example_export.py
@@ -18,3 +18,5 @@ listify = synchronizer.create_blocking(e2e_example_impl._listify, "listify", __n
 overloaded = synchronizer.create_blocking(e2e_example_impl._overloaded, "overloaded", __name__)
 
 returns_foo = synchronizer.create_blocking(e2e_example_impl._returns_foo, "returns_foo", __name__)
+
+wrapped_make_context = synchronizer.create_blocking(e2e_example_impl.make_context, "make_context", __name__)

--- a/test/type_stub_helpers/e2e_example_impl.py
+++ b/test/type_stub_helpers/e2e_example_impl.py
@@ -1,4 +1,7 @@
 from typing import AsyncGenerator, TypeVar, List, Union, overload
+import typing
+
+from synchronicity.async_wrap import asynccontextmanager
 
 
 class _Foo:
@@ -47,3 +50,9 @@ def _overloaded(arg: Union[str, int]):
 
 async def _returns_foo() -> _Foo:
     return _Foo("hello")
+
+
+@asynccontextmanager
+def make_context(a: float) -> typing.AsyncGenerator[str, None]:
+    yield "hello"
+

--- a/test/type_stub_helpers/e2e_example_impl.py
+++ b/test/type_stub_helpers/e2e_example_impl.py
@@ -55,4 +55,3 @@ async def _returns_foo() -> _Foo:
 @asynccontextmanager
 def make_context(a: float) -> typing.AsyncGenerator[str, None]:
     yield "hello"
-

--- a/test/type_stub_helpers/e2e_example_type_assertions.py
+++ b/test/type_stub_helpers/e2e_example_type_assertions.py
@@ -35,6 +35,7 @@ assert_type(e2e_example_export.overloaded(12), int)
 with e2e_example_export.wrapped_make_context(10.0) as c:
     assert_type(c, str)
 
+
 async def async_block() -> None:
     res = await e2e_example_export.returns_foo.aio(blocking_foo)
     assert_type(res, e2e_example_export.BlockingFoo)

--- a/test/type_stub_helpers/e2e_example_type_assertions.py
+++ b/test/type_stub_helpers/e2e_example_type_assertions.py
@@ -32,6 +32,16 @@ assert_type(e2e_example_export.overloaded("12"), float)
 assert_type(e2e_example_export.overloaded(12), int)
 
 
+with e2e_example_export.wrapped_make_context(10.0) as c:
+    assert_type(c, str)
+
 async def async_block() -> None:
     res = await e2e_example_export.returns_foo.aio(blocking_foo)
     assert_type(res, e2e_example_export.BlockingFoo)
+
+    async with e2e_example_export.wrapped_make_context(10.0) as c:
+        assert_type(c, str)
+
+    # not sure if this should actually be supported, but it is, for completeness:
+    async with e2e_example_export.wrapped_make_context.aio(10.0) as c:
+        assert_type(c, str)

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -1,5 +1,4 @@
 import functools
-from os import sync
 import typing
 
 import synchronicity
@@ -412,5 +411,8 @@ def test_wrapped_context_manager_is_both_blocking_and_async():
     wrapped_foo = synchronizer.create_blocking(foo, name="wrapped_foo")
     assert wrapped_foo.__annotations__["return"] == typing.AsyncContextManager[str]
     wrapped_foo_src = _function_source(wrapped_foo)
-    
-    assert "def __call__(self, arg: int) -> synchronicity.combined_types.AsyncAndBlockingContextManager[str]:" in wrapped_foo_src
+
+    assert (
+        "def __call__(self, arg: int) -> synchronicity.combined_types.AsyncAndBlockingContextManager[str]:"
+        in wrapped_foo_src
+    )

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -416,3 +416,4 @@ def test_wrapped_context_manager_is_both_blocking_and_async():
         "def __call__(self, arg: int) -> synchronicity.combined_types.AsyncAndBlockingContextManager[str]:"
         in wrapped_foo_src
     )
+    assert "AbstractAsyncContextManager" not in wrapped_foo_src

--- a/test/type_stub_translation_test.py
+++ b/test/type_stub_translation_test.py
@@ -2,7 +2,8 @@ import typing
 
 import pytest
 
-from synchronicity import Interface, Synchronizer
+from synchronicity import Interface, Synchronizer, combined_types
+import synchronicity
 from synchronicity.type_stubs import StubEmitter
 
 
@@ -32,7 +33,7 @@ def test_wrapped_class_keeps_class_annotations():
         (
             typing.AsyncContextManager[ImplType],
             Interface.BLOCKING,
-            typing.ContextManager[BlockingType],
+            combined_types.AsyncAndBlockingContextManager[BlockingType],
         ),
         (
             typing.AsyncContextManager[ImplType],

--- a/test/type_stub_translation_test.py
+++ b/test/type_stub_translation_test.py
@@ -3,7 +3,6 @@ import typing
 import pytest
 
 from synchronicity import Interface, Synchronizer, combined_types
-import synchronicity
 from synchronicity.type_stubs import StubEmitter
 
 


### PR DESCRIPTION
Output is now a protocol which is both a blocking and an async contextmanager at the same time (which the run-time type already was)
