### PR TITLE
Trigger cancellations before interpreter shutdown on SIGINT

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -166,7 +166,9 @@ class Synchronizer:
             self._thread = threading.Thread(target=thread_inner, daemon=True)
             self._thread.start()
             is_ready.wait()  # TODO: this might block for a very short time
-            self._install_sigint_handler(self._loop)
+            if threading.current_thread() == threading.main_thread():
+                self._install_sigint_handler(self._loop)
+
             return self._loop
 
     def _install_sigint_handler(self, loop):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -174,12 +174,12 @@ class Synchronizer:
     def _install_sigint_handler(self, loop):
         default_sigint_handler = signal.getsignal(signal.SIGINT)
 
-        def callback(signum, tb):
+        def callback(signum, frames):
             self._is_sigint_shutdown = True
             # make sure to close the loop BEFORE interpreter is finalizing
             # to allow threaded execution in cancellation handling (otherwise dns lookups etc. won't be possible)
             self._close_loop()
-            default_sigint_handler()  # raise keyboard interrupt in main thread etc.
+            default_sigint_handler(signum, frames)  # raise keyboard interrupt in main thread etc.
 
         signal.signal(signal.SIGINT, callback)
 

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -7,7 +7,6 @@ import functools
 import inspect
 import platform
 import signal
-import sys
 import threading
 import typing
 import warnings

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -1,5 +1,18 @@
 import asyncio
+import sys
+import time
+import traceback
+
 from synchronicity import Synchronizer
+
+
+def sync_shutdown_handler():
+    # this simulates any threading usage during event loop shutdown
+    # e.g. a network request using getaddrinfo etc.
+    # These are typically prohibited if the event loop shutdown is
+    # part of the python interpreter itself shutting down
+    time.sleep(0.1)
+    print("ran shutdown handler", flush=True)
 
 
 async def run():
@@ -9,6 +22,7 @@ async def run():
             await asyncio.sleep(0.3)
     except asyncio.CancelledError:
         print("cancelled")
+        await asyncio.to_thread(sync_shutdown_handler)
         raise
     finally:
         print("stopping")

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -20,7 +20,7 @@ async def run():
             await asyncio.sleep(0.3)
     except asyncio.CancelledError:
         print("cancelled")
-        await asyncio.to_thread(sync_shutdown_handler)
+        await asyncio.get_running_loop().run_in_executor(None, sync_shutdown_handler)
         raise
     finally:
         print("stopping")

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -1,7 +1,5 @@
 import asyncio
-import sys
 import time
-import traceback
 
 from synchronicity import Synchronizer
 

--- a/test/_shutdown.py
+++ b/test/_shutdown.py
@@ -33,4 +33,4 @@ s = Synchronizer()
 try:
     s.create_blocking(run)()
 except KeyboardInterrupt:
-    pass
+    print("got interrupt")

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -17,7 +17,8 @@ def test_shutdown():
         assert p.stdout.readline() == b"running\n"
     p.send_signal(signal.SIGINT)
     assert p.stdout.readline() == b"cancelled\n"
+    assert p.stdout.readline() == b"ran shutdown handler\n"
     assert p.stdout.readline() == b"stopping\n"
     assert p.stdout.readline() == b"exiting\n"
     stderr_content = p.stderr.read()
-    assert b"Traceback" not in stderr_content
+    assert stderr_content == b""

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -20,5 +20,6 @@ def test_shutdown():
     assert p.stdout.readline() == b"ran shutdown handler\n"
     assert p.stdout.readline() == b"stopping\n"
     assert p.stdout.readline() == b"exiting\n"
+    assert p.stdout.readline() == b"got interrupt\n"
     stderr_content = p.stderr.read()
     assert stderr_content == b""


### PR DESCRIPTION
This ensures all async exception handling of CancellationErrors can be executed, including any blocking thread-executor calls, e.g.:

```python
async def foo():
     try:
         await asyncio.sleep(1e10)
    finally:
         await asyncio.to_thread(some_blocking_op)
```

This allows for example doing network requests/cleanup, like modal's `AppClientDisconnect` request, since asyncios network stack uses blocking dns requests executed on a threadpool, which would otherwise be prevented by the interpreter not allowing threads to spawn once it has started shutting down and default-triggering cancellations on the synchronicity thread "too late".
