### PR TITLE
Check if instance is not None instead of truthiness

### DIFF
--- a/synchronicity/combined_types.py
+++ b/synchronicity/combined_types.py
@@ -39,7 +39,7 @@ class MethodWithAio:
         self._is_classmethod = is_classmethod
 
     def __get__(self, instance, owner=None):
-        bind_var = instance if instance and not self._is_classmethod else owner
+        bind_var = instance if instance is not None and not self._is_classmethod else owner
 
         bound_func = functools.wraps(self._func)(functools.partial(self._func, bind_var))  # bound blocking function
         self._synchronizer._update_wrapper(bound_func, self._func, interface=Interface.BLOCKING)


### PR DESCRIPTION
If an instance of a synchronized class implements `__len__(self)`, then its truthiness function `__bool__(self)` will call `__len__`, resulting in an infinite recursion and stack overflow under this implementation.

This PR fixes the logic in combined_types.py to check if something is not None, rather than checking for truthiness, resolving the infinite recursion.
