### PR TITLE
Fix exception when translating ContextVar[] generic in pyi files

### DIFF
--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -508,7 +508,7 @@ class StubEmitter:
                 )
             )
         except Exception:
-            raise Exception(f"Could not reformat generic {annotation.__origin__} with arguments {args}")
+            formatted_annotation = str(annotation)
 
         formatted_annotation = formatted_annotation.replace(
             "typing.Abstract", "typing."


### PR DESCRIPTION
This exception happens because only official `typing` classes have the `copy_with` method, like `typing.List`.

```
Traceback (most recent call last):
  File "/home/ubuntu/modal/venv/lib/python3.11/site-packages/synchronicity/type_stubs.py", line 505, in _formatannotation
    annotation.copy_with(
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: type object '_contextvars.ContextVar' has no attribute 'copy_with'
```
