### PR TITLE
Make compatible with Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
       - name: Install Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 dependencies = [
     "sigtools==4.0.1",
 ]
-requires-python = ">=3.7.9"
+requires-python = ">=3.8"
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -263,11 +263,11 @@ class Synchronizer:
                 return obj
 
     def _recurse_map(self, mapper, obj):
-        if type(obj) == list:
+        if type(obj) == list:  # noqa: E721
             return list(self._recurse_map(mapper, item) for item in obj)
-        elif type(obj) == tuple:
+        elif type(obj) == tuple:  # noqa: E721
             return tuple(self._recurse_map(mapper, item) for item in obj)
-        elif type(obj) == dict:
+        elif type(obj) == dict:  # noqa: E721
             return dict((key, self._recurse_map(mapper, item)) for key, item in obj.items())
         else:
             return mapper(obj)

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import asynccontextmanager
 import pytest
 
@@ -117,6 +118,7 @@ async def test_asynccontextmanager_nested():
 @pytest.mark.asyncio
 async def test_asynccontextmanager_with_in_async():
     r = s.create_async(Resource)()
-    with pytest.raises(AttributeError):
+    err_cls = AttributeError if sys.version_info < (3, 11) else TypeError
+    with pytest.raises(err_cls):
         with r.wrap():
             pass


### PR DESCRIPTION
This PR adds Python 3.11 and 3.12 to the CI build and addresses an issue that popped up when doing so (which blocks `modal-client` from being Python 3.12 compatible).

In Python 3.12, `TypeVar` no longer has a `__dict__` attribute. I gather that is a result of the work done to implement [PEP695](https://peps.python.org/pep-0695/), although I haven't surfaced any specific discussion of this apparently abrupt API break on `TypeVar`. That caused a few manipulations in `synchronicity` to fail.

There's also a new behavior in Python 3.12 where a `RuntimeError` is raised when functions registered with `atexit` start a new thread. We're seeing that coming out of synchronicity but aren't completely sure why. Since no behavior depends on the old behavior we're just going to swallow the exception for now and revisit later.

Also 3.7 is EOL, so I am dropping it from our CI matrix and bumping the `python-requires` in `pyproject.toml`. We recently dropped 3.7 support from the modal client too.

Fixes #118