### PR TITLE
Adds support for typing.Literal in type stub generation

### DIFF
--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -377,7 +377,11 @@ class StubEmitter:
                 return synchronizer._translate_out(type_annotation, interface)
             return type_annotation
 
-        mapped_args = tuple(self._translate_annotation(arg, synchronizer, interface, home_module) for arg in args)
+        if origin == typing.Literal:
+            mapped_args = args
+        else:
+            mapped_args = tuple(self._translate_annotation(arg, synchronizer, interface, home_module) for arg in args)
+
         if interface == Interface.BLOCKING:
             # blocking interface special generic translations:
             if origin == collections.abc.AsyncGenerator:

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -377,12 +377,14 @@ def test_ellipsis():
     src = _function_source(foo)
     assert "-> typing.Callable[..., typing.Any]" in src
 
+
 def test_typing_literal():
     def foo() -> typing.Literal["three", "str"]:
         ...
 
     src = _function_source(foo)
     assert "-> typing.Literal['three', 'str']" in src  # "str" should not be eval:ed in a Literal!
+
 
 def test_overloads_unwrapped_functions():
     with overload_tracking.patched_overload():

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -377,6 +377,12 @@ def test_ellipsis():
     src = _function_source(foo)
     assert "-> typing.Callable[..., typing.Any]" in src
 
+def test_typing_literal():
+    def foo() -> typing.Literal["three", "str"]:
+        ...
+
+    src = _function_source(foo)
+    assert "-> typing.Literal['three', 'str']" in src  # "str" should not be eval:ed in a Literal!
 
 def test_overloads_unwrapped_functions():
     with overload_tracking.patched_overload():


### PR DESCRIPTION
Previously it would evaluate the strings as potential Python types like with other nested annotations (e.g. `list["str"]` which means the same as `list[str]`). This is incorrect behavior for Literal specifically, which is fixed here.

Fixes MOD-2161