### PR TITLE
Adds decorators for marking functions for no input/output translation

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -315,7 +315,7 @@ class Synchronizer:
         loop = self._get_loop(start=True)
         # For futures, we unwrap the result at this point, not in f_wrapped
         coro = unwrap_coro_exception(coro)
-        coro = self._translate_coro_out(coro, interface)
+        coro = self._translate_coro_out(coro, interface, original_func)
         return asyncio.run_coroutine_threadsafe(coro, loop)
 
     async def _run_function_async(self, coro, interface, original_func):

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -2,7 +2,7 @@ import asyncio
 import concurrent.futures
 import inspect
 from typing import Coroutine
-from unittest.mock import MagicMock, ANY
+from unittest.mock import MagicMock
 
 import pytest
 import time
@@ -493,9 +493,9 @@ async def test_blocking_nested_aio_returns_blocking_obj():
     assert isinstance(self_from_aio_interface, BlockingFoo)
 
 
-
 def test_no_input_translation(monkeypatch):
     s = Synchronizer()
+
     @s.create_blocking
     def does_input_translation(arg: float) -> str:
         return str(arg)
@@ -517,6 +517,7 @@ def test_no_input_translation(monkeypatch):
 
 def test_no_output_translation(monkeypatch):
     s = Synchronizer()
+
     @s.create_blocking
     def does_input_translation(arg: float) -> str:
         return str(arg)

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -511,7 +511,7 @@ def test_no_input_translation(monkeypatch):
     in_translate_spy.assert_called_once_with(3.14)
 
     in_translate_spy.reset_mock()
-    without_input_translation(3.14)  # test without decorator, this *should* do input translation
+    without_input_translation(3.14)
     in_translate_spy.assert_not_called()
 
 

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 import inspect
 from typing import Coroutine
+from unittest.mock import MagicMock, ANY
 
 import pytest
 import time
@@ -490,3 +491,46 @@ async def test_blocking_nested_aio_returns_blocking_obj():
     self_from_aio_interface = await original.get_self.aio()
     assert self_from_aio_interface == original
     assert isinstance(self_from_aio_interface, BlockingFoo)
+
+
+
+def test_no_input_translation(monkeypatch):
+    s = Synchronizer()
+    @s.create_blocking
+    def does_input_translation(arg: float) -> str:
+        return str(arg)
+
+    @s.create_blocking
+    @s.no_input_translation
+    async def without_input_translation(arg: float) -> str:
+        return str(arg)
+
+    in_translate_spy = MagicMock(wraps=s._translate_scalar_in)
+    monkeypatch.setattr(s, "_translate_scalar_in", in_translate_spy)
+    does_input_translation(3.14)  # test without decorator, this *should* do input translation
+    in_translate_spy.assert_called_once_with(3.14)
+
+    in_translate_spy.reset_mock()
+    without_input_translation(3.14)  # test without decorator, this *should* do input translation
+    in_translate_spy.assert_not_called()
+
+
+def test_no_output_translation(monkeypatch):
+    s = Synchronizer()
+    @s.create_blocking
+    def does_input_translation(arg: float) -> str:
+        return str(arg)
+
+    @s.create_blocking
+    @s.no_output_translation
+    async def without_output_translation(arg: float) -> str:
+        return str(arg)
+
+    out_translate_spy = MagicMock(wraps=s._translate_scalar_out)
+    monkeypatch.setattr(s, "_translate_scalar_out", out_translate_spy)
+    does_input_translation(3.14)  # test without decorator, this *should* do input translation
+    out_translate_spy.assert_called_once_with("3.14", Interface.BLOCKING)
+
+    out_translate_spy.reset_mock()
+    without_output_translation(3.14)  # test without decorator, this *should* do input translation
+    out_translate_spy.assert_not_called()

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -519,7 +519,7 @@ def test_no_output_translation(monkeypatch):
     s = Synchronizer()
 
     @s.create_blocking
-    def does_input_translation(arg: float) -> str:
+    def does_output_translation(arg: float) -> str:
         return str(arg)
 
     @s.create_blocking
@@ -529,9 +529,9 @@ def test_no_output_translation(monkeypatch):
 
     out_translate_spy = MagicMock(wraps=s._translate_scalar_out)
     monkeypatch.setattr(s, "_translate_scalar_out", out_translate_spy)
-    does_input_translation(3.14)  # test without decorator, this *should* do input translation
+    does_output_translation(3.14)  # test without decorator, this *should* do input translation
     out_translate_spy.assert_called_once_with("3.14", Interface.BLOCKING)
 
     out_translate_spy.reset_mock()
-    without_output_translation(3.14)  # test without decorator, this *should* do input translation
+    without_output_translation(3.14)
     out_translate_spy.assert_not_called()


### PR DESCRIPTION
Normally synchronicity will inspect all parameters and return values to/from wrapped functions to make sure that synchronicity-wrapped parameters are unwrapped and that async return values (or "internal" synchronicity objects) are rewrapped.
This inspection is recursively into certain collection data types (lists etc.) as well, causing a noticeable performance hit for large data structures. 

This patch adds three new decorators to let implementors skip these inspection when it's known that it won't be applicable:
```
@synchronizer.no_input_translation

@synchronizer.no_output_translation

@synchronizer.no_io_translation  # does both of the above
```