### PR TITLE
Fix for `__aiter__` wrappers sometimes leaking StopAsyncIteration

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -305,6 +305,7 @@ class Synchronizer:
         loop = self._get_loop(start=True)
         fut = asyncio.run_coroutine_threadsafe(coro, loop)
         value = fut.result()
+
         if getattr(original_func, self._output_translation_attr, True):
             return self._translate_out(value, interface)
         return value
@@ -447,6 +448,9 @@ class Synchronizer:
                     # This is the exit point, so we need to unwrap the exception here
                     try:
                         return self._run_function_sync(res, interface, f)
+                    except StopAsyncIteration:
+                        # this is a special case for handling __next__ wrappers around __anext__ that raises StopAsyncIteration
+                        raise StopIteration()
                     except UserCodeException as uc_exc:
                         # Used to skip a frame when called from `proxy_method`.
                         if unwrap_user_excs and not (Interface.BLOCKING and include_aio_interface):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -449,7 +449,8 @@ class Synchronizer:
                     try:
                         return self._run_function_sync(res, interface, f)
                     except StopAsyncIteration:
-                        # this is a special case for handling __next__ wrappers around __anext__ that raises StopAsyncIteration
+                        # this is a special case for handling __next__ wrappers around
+                        # __anext__ that raises StopAsyncIteration
                         raise StopIteration()
                     except UserCodeException as uc_exc:
                         # Used to skip a frame when called from `proxy_method`.

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -1,8 +1,6 @@
 import asyncio
 import concurrent.futures
 import inspect
-import typing
-
 import pytest
 import time
 from typing import Coroutine

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -1,6 +1,8 @@
 import asyncio
 import concurrent.futures
 import inspect
+import typing
+
 import pytest
 import time
 from typing import Coroutine
@@ -534,3 +536,35 @@ def test_no_output_translation(monkeypatch):
     out_translate_spy.reset_mock()
     without_output_translation(3.14)
     out_translate_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_async_aiter():
+    async def some_async_gen():
+        yield "foo"
+        yield "bar"
+
+    class It:
+        def __aiter__(self):
+            self._gen = some_async_gen()
+            return self
+
+        async def __anext__(self):
+            value = await self._gen.__anext__()
+            return value
+
+    s = Synchronizer()
+    WrappedIt = s.create_blocking(It, name="WrappedIt")
+
+    # just a sanity check of the original iterable:
+    orig_async_it = It()
+    assert [v async for v in orig_async_it] == ["foo", "bar"]
+
+    # check async iteration on the wrapped iterator
+    it = WrappedIt()
+    assert [v async for v in it] == ["foo", "bar"]
+
+    # check sync iteration on the wrapped iterator
+    it = WrappedIt()
+    assert list(it) == ["foo", "bar"]
+


### PR DESCRIPTION
This could previously happen if an `__aiter__` returned an async iterator *which is not* an async generator, i.e. an object that just happens to have an `__anext__`

Not super happy with adding a special case wrapper for the return value like this, but the more well structured solution of special-casing `__anext__` translation felt even more clunky...


Also, this is another of the scenarios that I think would be much cleaner in a "synchronicity rewrite" that uses type annotations rather than run time types to wrap and unwrap objects.