### PR TITLE
Fix copy_with not existing outside of generic aliases

### DIFF
--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -1,3 +1,4 @@
+import collections
 import functools
 import typing
 
@@ -425,3 +426,18 @@ def test_wrapped_context_manager_is_both_blocking_and_async():
         in wrapped_foo_src
     )
     assert "AbstractAsyncContextManager" not in wrapped_foo_src
+
+
+def test_collections_iterator():
+    def foo() -> collections.abc.Iterator[int]:
+        class MyIterator(collections.abc.Iterator):
+            def __iter__(self) -> collections.abc.Iterator[int]:
+                return self
+
+            def __next__(self) -> int:
+                return 1
+
+        return MyIterator()
+
+    src = _function_source(foo)
+    assert "-> collections.abc.Iterator[int]" in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -1,9 +1,8 @@
 import collections
 import functools
+import pytest
 import sys
 import typing
-
-import pytest
 
 import synchronicity
 from synchronicity import overload_tracking

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -1,6 +1,9 @@
 import collections
 import functools
+import sys
 import typing
+
+import pytest
 
 import synchronicity
 from synchronicity import overload_tracking
@@ -428,6 +431,7 @@ def test_wrapped_context_manager_is_both_blocking_and_async():
     assert "AbstractAsyncContextManager" not in wrapped_foo_src
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="collections.abc.Iterator isn't a generic type before Python 3.9")
 def test_collections_iterator():
     def foo() -> collections.abc.Iterator[int]:
         class MyIterator(collections.abc.Iterator):


### PR DESCRIPTION
Bug found by @mwaskom 

`copy_with` does not exist for the original generics like `colllections.abc.*` so those would break type stubs when used (!)
