### PR TITLE
Support property setter/deleters

### DIFF
--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -188,6 +188,14 @@ class StubEmitter:
                 fn_source = self._get_function_source_with_overloads(entity.fget, entity_name, body_indent_level)
                 methods.append(f"{body_indent}@property\n{fn_source}")
 
+                if entity.fset:
+                    fn_source = self._get_function_source_with_overloads(entity.fset, entity_name, body_indent_level)
+                    methods.append(f"{body_indent}@{entity_name}.setter\n{fn_source}")
+
+                if entity.fdel:
+                    fn_source = self._get_function_source_with_overloads(entity.fdel, entity_name, body_indent_level)
+                    methods.append(f"{body_indent}@{entity_name}.deleter\n{fn_source}")
+
             elif isinstance(entity, FunctionWithAio):
                 # Note: FunctionWithAio is used for staticmethods
                 methods.append(

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -116,6 +116,14 @@ class MixedClass:
     def some_property(self) -> str:
         return ""
 
+    @some_property.setter
+    def some_property(self, val):
+        print(val)
+
+    @some_property.deleter
+    def some_property(self, val):
+        print(val)
+
 
 def test_class_generation():
     emitter = StubEmitter(__name__)
@@ -139,6 +147,8 @@ def test_class_generation():
     assert_in_after_last(f"{indent}@classmethod\n{indent}def some_class_method(cls) -> int:\n{indent * 2}...")
     assert_in_after_last(f"{indent}@staticmethod\n{indent}def some_staticmethod() -> float:")
     assert_in_after_last(f"{indent}@property\n{indent}def some_property(self) -> str:")
+    assert_in_after_last(f"{indent}@some_property.setter\n{indent}def some_property(self, val):")
+    assert_in_after_last(f"{indent}@some_property.deleter\n{indent}def some_property(self, val):")
 
 
 def merged_signature(*sigs):


### PR DESCRIPTION
https://github.com/modal-labs/modal-client/pull/1576 is failing on the lack of property setter support in synchronicity type stubs. Mypy outputs this:

```
 test/image_test.py:48: error: Property "image" defined in "Stub" is read-only  [misc]
```

The generated stubs don't have anything for the setter. After this fairly trivial addition, they have, and mypy is no longer complaining.

Added deleters too just for fun.