### PR TITLE
Support type stub generation for dataclasses

### DIFF
--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -265,7 +265,7 @@ class StubEmitter:
                 if isinstance(arg, type):
                     field_params[param] = arg.__name__
                 else:
-                    field_params[param] = arg
+                    field_params[param] = repr(arg)
             field_param_str = ", ".join(f"{param}={arg}" for param, arg in field_params.items())
             field_annotations.append(f"{indent}{name}: {annot} = dataclasses.field({field_param_str})")
 

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -253,6 +253,7 @@ class StubEmitter:
             annot = entity.__annotations__[name]
             if isinstance(annot, type):
                 if annot.__module__ not in {"builtins", entity.__module__}:
+                    self.imports.add(annot.__module__)
                     prefix = f"{annot.__module__}."
                 else:
                     prefix = ""

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -252,7 +252,11 @@ class StubEmitter:
             indent = self._indent(1)
             annot = entity.__annotations__[name]
             if isinstance(annot, type):
-                annot = annot.__name__
+                if annot.__module__ not in {"builtins", entity.__module__}:
+                    prefix = f"{annot.__module__}."
+                else:
+                    prefix = ""
+                annot = f"{prefix}{annot.__name__}"
             field_params = {}
             for param in ["default", "default_factory", "init", "kw_only"]:
                 arg = getattr(field, param)

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -472,9 +472,11 @@ def test_dataclass() -> None:
         bar: Path
         baz: Iterable[int]
         qux: int = 2
+        kab: str = "hello"
         hep: list = field(default_factory=list)
 
     src = _dataclass_source(MyDataclass)
+    print(src)
     assert "import dataclasses" in src
     assert "@dataclasses.dataclass(" in src
     assert "frozen=True" in src
@@ -482,5 +484,6 @@ def test_dataclass() -> None:
     assert "bar: pathlib.Path" in src
     assert "baz: typing.Iterable[int]" in src
     assert "qux: int = dataclasses.field(default=2" in src
+    assert "kab: str = dataclasses.field(default='hello'" in src
     assert "hep: list = dataclasses.field(default_factory=list" in src
     assert "def " not in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -4,6 +4,8 @@ import pytest
 import sys
 import typing
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
 
 import synchronicity
 from synchronicity import overload_tracking
@@ -467,14 +469,18 @@ def test_dataclass() -> None:
     @dataclass(frozen=True)
     class MyDataclass:
         foo: str
-        bar: int = 2
-        buz: list = field(default_factory=list)
+        bar: Path
+        baz: Iterable[int]
+        qux: int = 2
+        hep: list = field(default_factory=list)
 
     src = _dataclass_source(MyDataclass)
     assert "import dataclasses" in src
     assert "@dataclasses.dataclass(" in src
     assert "frozen=True" in src
     assert "foo: str" in src
-    assert "bar: int = dataclasses.field(default=2" in src
-    assert "buz: list = dataclasses.field(default_factory=list" in src
+    assert "bar: pathlib.Path" in src
+    assert "baz: typing.Iterable[int]" in src
+    assert "qux: int = dataclasses.field(default=2" in src
+    assert "hep: list = dataclasses.field(default_factory=list" in src
     assert "def " not in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -464,13 +464,17 @@ def test_collections_iterator():
 
 
 def test_dataclass() -> None:
-    @dataclass
+    @dataclass(frozen=True)
     class MyDataclass:
         foo: str
         bar: int = 2
         buz: list = field(default_factory=list)
 
     src = _dataclass_source(MyDataclass)
-    assert "bar: int = 2" in src
-    assert "field(default_factory=list)" in src
+    assert "import dataclasses" in src
+    assert "@dataclasses.dataclass(" in src
+    assert "frozen=True" in src
+    assert "foo: str" in src
+    assert "bar: int = dataclasses.field(default=2" in src
+    assert "buz: list = dataclasses.field(default_factory=list" in src
     assert "def " not in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -3,6 +3,7 @@ import functools
 import pytest
 import sys
 import typing
+from dataclasses import dataclass, field
 
 import synchronicity
 from synchronicity import overload_tracking
@@ -41,6 +42,12 @@ def _function_source(func, target_module=__name__):
 def _class_source(cls, target_module=__name__):
     stub_emitter = StubEmitter(target_module)
     stub_emitter.add_class(cls, cls.__name__)
+    return stub_emitter.get_source()
+
+
+def _dataclass_source(cls, target_module=__name__):
+    stub_emitter = StubEmitter(target_module)
+    stub_emitter.add_dataclass(cls, cls.__name__)
     return stub_emitter.get_source()
 
 
@@ -454,3 +461,16 @@ def test_collections_iterator():
 
     src = _function_source(foo)
     assert "-> collections.abc.Iterator[int]" in src
+
+
+def test_dataclass() -> None:
+    @dataclass
+    class MyDataclass:
+        foo: str
+        bar: int = 2
+        buz: list = field(default_factory=list)
+
+    src = _dataclass_source(MyDataclass)
+    assert "bar: int = 2" in src
+    assert "field(default_factory=list)" in src
+    assert "def " not in src


### PR DESCRIPTION
Our existing logic mangles dataclass definitions by resolving them to a fleshed out class (with an `__init__` and the other methods added by the `dataclass`) decorator. Maybe this is fine but it broke for me because I had a `field()` default value which don't have a "nice" repr.

It doesn't seem like we need to translate dataclass definitions for type stubs so my solution here is to just use the literal source; open to other ideas though!