### PR TITLE
Support Literal type aliases

### DIFF
--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -374,6 +374,9 @@ def _ident(b: _B) -> _B:
 ident = synchronizer.create_blocking(_ident, "ident", __name__)
 
 
+literal_foo = typing.Literal["foo"]
+
+
 def test_translated_bound_type_vars():
     emitter = StubEmitter(__name__)
     emitter.add_type_var(B, "B")
@@ -381,6 +384,12 @@ def test_translated_bound_type_vars():
     src = emitter.get_source()
     assert 'B = typing.TypeVar("B", bound="str")' in src
     assert "def ident(b: B) -> B" in src
+
+
+def test_literal_alias():
+    emitter = StubEmitter.from_module(sys.modules[__name__])
+    src = emitter.get_source()
+    assert "literal_foo = typing.Literal['foo']" in src
 
 
 def test_ellipsis():


### PR DESCRIPTION
Fixes a bug where we dropped `Literal` aliases from the type stubs, which is problem in some edge cases because `Literal` types can also be useful as the source of truth for runtime validation of inputs.