### PR TITLE
Allow libraries to define custom MethodWithAio methods

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -626,6 +626,9 @@ class Synchronizer:
                 new_dict[k] = self._wrap_proxy_classmethod(v, interface)
             elif isinstance(v, property):
                 new_dict[k] = self._wrap_proxy_property(v, interface)
+            elif isinstance(v, MethodWithAio):
+                # if library defines its own "synchronicity-like" interface we transfer it "as is" to the wrapper
+                new_dict[k] = v
             elif callable(v):
                 new_dict[k] = self._wrap_proxy_method(v, interface)
 


### PR DESCRIPTION
When you want a non-wrapped version of a method but still keep the intance.method.aio interface for async invocation
