### PR TITLE
Type-stubs: add support for ParamSpec and forwarding typevars to wrapped methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.6.6"
+version = "0.6.7"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.6.4"
+version = "0.6.5"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.6.5"
+version = "0.6.6"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.6.3"
+version = "0.6.4"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -133,7 +133,8 @@ class Synchronizer:
         self.create_blocking(self._ctx_mgr_cls)
 
         # TODO: ugly, remove this and the whole require_already_wrapped:
-        self.create_blocking(typing.Generic, "WrappedGeneric")
+
+        self.create_blocking(typing.Generic, "WrappedGeneric", __name__)
 
         atexit.register(self._close_loop)
 

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -626,6 +626,9 @@ class Synchronizer:
                 new_dict[k] = self._wrap_proxy_classmethod(v, interface)
             elif isinstance(v, property):
                 new_dict[k] = self._wrap_proxy_property(v, interface)
+            elif isinstance(v, MethodWithAio):
+                # if library defines its own "synchronicity-like" interface we transfer it "as is" to the wrapper
+                new_dict[k] = v
             elif callable(v):
                 new_dict[k] = self._wrap_proxy_method(v, interface)
 

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -7,9 +7,10 @@ import inspect
 import platform
 import threading
 import typing
-import typing_extensions
 import warnings
 from typing import ForwardRef, Optional
+
+import typing_extensions
 
 from synchronicity.annotations import evaluated_annotation
 from synchronicity.combined_types import FunctionWithAio, MethodWithAio
@@ -261,7 +262,7 @@ class Synchronizer:
                 return cls_dct[self._wrapped_attr][interface]
             else:
                 return obj
-        elif isinstance(obj, (typing.TypeVar, typing.ParamSpec)):
+        elif isinstance(obj, (typing.TypeVar, typing_extensions.ParamSpec)):
             if hasattr(obj, self._wrapped_attr):
                 return getattr(obj, self._wrapped_attr)[interface]
             else:
@@ -729,7 +730,7 @@ class Synchronizer:
 
     def _wrap_param_spec(self, obj, interface, name, target_module):
         # TODO(elias): Refactor - since this isn't used for live apps, move type stub generation into genstub
-        new_obj = typing.ParamSpec(name)  # noqa
+        new_obj = typing_extensions.ParamSpec(name)  # noqa
         setattr(new_obj, self._original_attr, obj)
         setattr(new_obj, SYNCHRONIZER_ATTR, self)
         setattr(new_obj, TARGET_INTERFACE_ATTR, interface)

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -132,7 +132,8 @@ class Synchronizer:
         self.create_async(self._ctx_mgr_cls)
         self.create_blocking(self._ctx_mgr_cls)
 
-        self.create_blocking(typing.Generic)
+        # TODO: ugly, remove this and the whole require_already_wrapped:
+        self.create_blocking(typing.Generic, "WrappedGeneric")
 
         atexit.register(self._close_loop)
 

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -185,6 +185,9 @@ class Synchronizer:
             self._thread.join()
             self._thread = None
 
+    def __del__(self):
+        self._close_loop()
+
     def _get_loop(self, start=False):
         if self._loop is None and start:
             return self._start_loop()

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -238,7 +238,7 @@ class StubEmitter:
             bases.append(self._translate_global_annotation(b, cls))
         return bases
 
-    def add_class(self, cls, name):
+    def add_class(self, cls, name) -> None:
         self.global_types.add(name)
 
         if issubclass(cls, enum.Enum):
@@ -583,7 +583,7 @@ class StubEmitter:
             if origin == collections.abc.Coroutine:
                 return mapped_args[2]
 
-        # first see if the generic itself needs translation
+        # first see if the generic itself needs translation (in case of wrapped custom generics)
         if origin.__module__ not in (
             "typing",
             "collections.abc",
@@ -592,7 +592,7 @@ class StubEmitter:
         ):  # don't translate built in generics in type annotations, even if they have been synchronicity wrapped
             # for base-class compatibility (e.g. AsyncContextManager, typing.Generic), otherwise it will break typing
             translated_origin = self._translate_annotation(origin, synchronizer, interface, home_module)
-            t = translated_origin[mapped_args]  # this seems to fall back to the __class_getitem__ of the base
+            t = translated_origin[mapped_args]  # type: ignore  # this seems to fall back to the __class_getitem__ of the implementation class
             # In order to get the right origin and args on the output, we manuall have to assign them:
             # TODO: We could probably fix this in the synchronicity layer by making wrapped generics true generics, or
             #  hackily by not letting __class_getitem__ proxy to the wrapped class' method for custom generics

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -110,9 +110,7 @@ def _get_type_vars(typ, synchronizer, home_module):
             try:
                 typ = evaluated_annotation(typ, declaration_module=home_module)
             except Exception:
-                logger.exception(
-                    f"Error when evaluating {typ} in {home_module}. Falling back to string typ"
-                )
+                logger.exception(f"Error when evaluating {typ} in {home_module}. Falling back to string typ")
                 return ret
             return _get_type_vars(typ, synchronizer, home_module)
     return ret
@@ -141,6 +139,7 @@ def safe_get_args(annotation):
             args = (args[0][0],) + args[1:]
 
     return args
+
 
 def get_specific_generic_name(annotation):
     """get the name of the generic type of a "specific" type (with args)

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -120,9 +120,8 @@ def _get_type_vars(typ, synchronizer):
     return ret
 
 def _get_func_type_vars(func, synchronizer: synchronicity.Synchronizer) -> typing.Set[type]:
-    annos = inspect.get_annotations(func, eval_str=False)
     ret = set()
-    for typ in annos.values():
+    for typ in getattr(func, "__annotations__", {}).values():
         ret |= _get_type_vars(typ, synchronizer)
     return ret
 

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -76,7 +76,7 @@ def add_prefix_arg(arg_name, remove_args=0):
 
     return inject_arg_func
 
-def replace_type_vars(replacement_dict: dict[type, type]):
+def replace_type_vars(replacement_dict: typing.Dict[type, type]):
     def _replace_type_vars_rec(tp: typing.Type[typing.Any]):
         origin = typing.get_origin(tp)
         args = typing.get_args(tp)
@@ -538,9 +538,7 @@ class StubEmitter:
 
             if origin == collections.abc.Coroutine:
                 return mapped_args[2]
-        if isinstance(type_annotation, (typing.ParamSpecArgs, typing.ParamSpecKwargs)):
-            # if this is a P.args or P.kwargs, check if P needs translation!
-            print("hej", type_annotation)
+
         # first see if the generic itself needs translation
         if origin.__module__ not in (
             "typing",

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -405,12 +405,12 @@ class StubEmitter:
 
     def add_type_var(self, type_var: typing.Union[typing.TypeVar, typing_extensions.ParamSpec], name):
         # TODO: deduplicate vs type vars that have already been added in the same file
-        if isinstance(type_var, typing.TypeVar):
-            type_module = "typing"
-            type_name = "TypeVar"
-        elif isinstance(type_var, typing_extensions.ParamSpec):
+        if isinstance(type_var, typing_extensions.ParamSpec):
             type_module = "typing_extensions"  # this ensures stubs created by newer Python's still work on Python 3.9
             type_name = "ParamSpec"
+        elif isinstance(type_var, typing.TypeVar):
+            type_module = "typing"
+            type_name = "TypeVar"
         else:
             raise TypeError("Not a TypeVar/ParamSpec")
 

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -110,7 +110,7 @@ def _get_type_vars(typ, synchronizer):
         # check if it's translated (due to bounds= attributes etc.)
         typ = synchronizer._translate_out(typ, Interface.BLOCKING)
         ret.add(typ)
-    elif isinstance(typ, (typing.ParamSpecArgs, typing.ParamSpecKwargs)):
+    elif isinstance(typ, (typing_extensions.ParamSpecArgs, typing_extensions.ParamSpecKwargs)):
         param_spec = origin
         param_spec = synchronizer._translate_out(param_spec, Interface.BLOCKING)
         ret.add(param_spec)
@@ -307,7 +307,7 @@ class StubEmitter:
         entity: typing.Union[MethodWithAio, FunctionWithAio],
         entity_name,
         body_indent_level,
-        parent_generic_type_vars: typing.Set[type] = set(),  # if this is a method of a Generic class - the set of type vars
+        parent_generic_type_vars: typing.Set[type] = set(),  # if a method of a Generic class - the set of type vars
     ) -> str:
         if isinstance(entity, FunctionWithAio):
             transform_signature = add_prefix_arg(
@@ -382,7 +382,7 @@ class StubEmitter:
 """
         return protocol_attr
 
-    def add_type_var(self, type_var: typing.Union[typing.TypeVar, typing.ParamSpec], name):
+    def add_type_var(self, type_var: typing.Union[typing.TypeVar, typing_extensions.ParamSpec], name):
         # TODO: deduplicate
         type_module = type(type_var).__module__  # typing/typing_extensions
         self.imports.add(type_module)

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -626,11 +626,15 @@ class StubEmitter:
 
         origin = getattr(annotation, "__origin__", None)
         assert not isinstance(annotation, typing.ForwardRef)  # Forward refs should already have been evaluated!
-        args = getattr(annotation, "__args__", None)
+        args = typing.get_args(annotation)
 
         if origin is None or not args:
             if annotation == Ellipsis:
                 return "..."
+            if isinstance(annotation, list):
+                # e.g. first argument to typing.Callable
+                subargs = ",".join([self._formatannotation(arg) for arg in annotation])
+                return f"[{subargs}]"
             if isinstance(annotation, type) or isinstance(annotation, (TypeVar, typing_extensions.ParamSpec)):
                 if annotation == type(None):  # check for "NoneType"
                     return "None"
@@ -653,6 +657,7 @@ class StubEmitter:
 
             if origin is collections.abc.Callable:
                 # special case for dealing with the first argument sometimes getting recast to a list when it shouldn't
+
                 argstr = ", ".join(repr(a) for a in formatted_args)
                 formatted_annotation = f"typing.Callable[{argstr}]"
             else:

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -404,7 +404,7 @@ class StubEmitter:
         for tvar in typevar_overlap:
             replacement_typevar_name = tvar.__name__ + "_INNER"
             if isinstance(tvar, typing_extensions.ParamSpec):
-                new_tvar = typing_extensions.ParamSpec(replacement_typevar_name)
+                new_tvar = typing_extensions.ParamSpec(replacement_typevar_name)  # type: ignore
             else:
                 new_tvar = typing.TypeVar(replacement_typevar_name, covariant=True)  # type: ignore
             new_tvar.__module__ = self.target_module  # avoid referencing synchronicity.type_stubs

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -217,7 +217,7 @@ class StubEmitter:
             return
 
         bases = []
-        generic_type_vars: set[type] = set()
+        generic_type_vars: typing.Set[type] = set()
         for b in self._get_translated_class_bases(cls):
             if b is not object:
                 bases.append(self._formatannotation(b))
@@ -307,7 +307,7 @@ class StubEmitter:
         entity: typing.Union[MethodWithAio, FunctionWithAio],
         entity_name,
         body_indent_level,
-        parent_generic_type_vars: set[type] = set(),  # if this is a method of a Generic class - the set of type vars
+        parent_generic_type_vars: typing.Set[type] = set(),  # if this is a method of a Generic class - the set of type vars
     ) -> str:
         if isinstance(entity, FunctionWithAio):
             transform_signature = add_prefix_arg(

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -657,9 +657,9 @@ class StubEmitter:
 
         if origin is None or not args:
             if annotation == typing.Sized:
-                return "typing.Sized"  # hard-coded to fix Python 3.8(+?) where the repr is "typing.Sized[]" for some reason
+                return "typing.Sized"  # fix Python 3.8(+?) where the repr is "typing.Sized[]" for some reason
             if annotation == typing.Hashable:
-                return "typing.Hashable"  # hard-coded to fix Python 3.8(+?) where the repr is "typing.Hashable[]" for some reason
+                return "typing.Hashable"  # fix Python 3.8(+?) where the repr is "typing.Hashable[]" for some reason
 
             if annotation == Ellipsis:
                 return "..."

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -119,7 +119,7 @@ def _get_type_vars(typ, synchronizer):
             ret |= _get_type_vars(arg, synchronizer)
     return ret
 
-def _get_func_type_vars(func, synchronizer: synchronicity.Synchronizer) -> set[type]:
+def _get_func_type_vars(func, synchronizer: synchronicity.Synchronizer) -> typing.Set[type]:
     annos = inspect.get_annotations(func, eval_str=False)
     ret = set()
     for typ in annos.values():

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -14,13 +14,13 @@ import importlib
 import inspect
 import sys
 import typing
-import typing_extensions
 from logging import getLogger
 from pathlib import Path
 from typing import Generic, TypeVar
 from unittest import mock
 
 import sigtools.specifiers  # type: ignore
+import typing_extensions
 from sigtools._signatures import EmptyAnnotation, UpgradedAnnotation, UpgradedParameter  # type: ignore
 
 import synchronicity
@@ -307,7 +307,7 @@ class StubEmitter:
         entity: typing.Union[MethodWithAio, FunctionWithAio],
         entity_name,
         body_indent_level,
-        parent_generic_type_vars: set[type] = set(),  # if this is a method of a Generic class - this is the set of type var names
+        parent_generic_type_vars: set[type] = set(),  # if this is a method of a Generic class - the set of type vars
     ) -> str:
         if isinstance(entity, FunctionWithAio):
             transform_signature = add_prefix_arg(
@@ -353,7 +353,8 @@ class StubEmitter:
             declaration_argstr = ", ".join(typevar_replacements[tvar].__name__ for tvar in typevar_overlap)
             protocol_declaration_type_var_spec = f"[{declaration_argstr}]"
             # recursively replace any used type vars in the function annotation with newly created
-            final_transform_signature = lambda sig: replace_type_vars(typevar_replacements)(transform_signature(sig))
+            def final_transform_signature(sig):
+                return replace_type_vars(typevar_replacements)(transform_signature(sig))
         else:
             parent_type_var_names_spec = ""
             protocol_declaration_type_var_spec = ""
@@ -644,7 +645,10 @@ class StubEmitter:
                 if annotation.__module__ in ("builtins", self.target_module):
                     return name
                 if annotation.__module__ is None:
-                    raise Exception(f"{annotation} has __module__ == None - did you forget to specify target module on a blocking type?")
+                    raise Exception(
+                        f"{annotation} has __module__ == None - did you forget"
+                        " to specify target module on a blocking type?"
+                    )
                 return annotation.__module__ + "." + name
             return repr(annotation)
         # generic:

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -137,10 +137,10 @@ def safe_get_args(annotation):
     if sys.version_info[:2] <= (3, 9) and typing.get_origin(annotation) == collections.abc.Callable:
         if (
             args
-            and type(args[0]) == list
+            and type(args[0]) == list  # noqa  (want specific type)
             and args[0]
             and isinstance(args[0][0], (typing_extensions.ParamSpec, type(...)))
-        ):  # noqa
+        ):
             args = (args[0][0],) + args[1:]
 
     return args

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -9,6 +9,7 @@ Improvement Ideas:
 import collections
 import collections.abc
 import contextlib
+import enum
 import importlib
 import inspect
 import sys
@@ -158,6 +159,13 @@ class StubEmitter:
 
     def add_class(self, cls, name):
         self.global_types.add(name)
+
+        if issubclass(cls, enum.Enum):
+            # Do not translate Enum classes.
+            self.imports.add("enum")
+            self.parts.append(inspect.getsource(cls))
+            return
+
         bases = []
         for b in self._get_translated_class_bases(cls):
             if b is not object:

--- a/test/async_wrap_test.py
+++ b/test/async_wrap_test.py
@@ -37,7 +37,7 @@ def test_wrap_asynccontextmanager_annotations():
     assert foo.__annotations__["return"] == typing.AsyncContextManager[int]
 
 
-def test_wrap_staticmethod():
+def test_wrap_staticmethod(synchronizer):
     class Foo:
         @staticmethod
         async def a_static_method() -> typing.Awaitable[str]:
@@ -46,7 +46,6 @@ def test_wrap_staticmethod():
 
             return wrapped()
 
-    synchronizer = synchronicity.Synchronizer()
     BlockingFoo = synchronizer.create_blocking(Foo)
     AsyncFoo = synchronizer.create_async(Foo)
 

--- a/test/async_wrap_test.py
+++ b/test/async_wrap_test.py
@@ -1,7 +1,6 @@
 import inspect
 import typing
 
-import synchronicity
 from synchronicity import Interface, async_wrap
 from synchronicity.async_wrap import wraps_by_interface
 from synchronicity.synchronizer import FunctionWithAio

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -13,9 +13,6 @@ async def error():
     raise Exception("problem")
 
 
-s = Synchronizer()
-
-
 class Resource:
     def __init__(self):
         self.state = "none"
@@ -42,8 +39,8 @@ class Resource:
             yield
 
 
-def test_asynccontextmanager_sync():
-    r = s.create_blocking(Resource)()
+def test_asynccontextmanager_sync(synchronizer):
+    r = synchronizer.create_blocking(Resource)()
     assert r.get_state() == "none"
     with r.wrap():
         assert r.get_state() == "entered"
@@ -51,8 +48,8 @@ def test_asynccontextmanager_sync():
 
 
 @pytest.mark.asyncio
-async def test_asynccontextmanager_async():
-    r = s.create_async(Resource)()
+async def test_asynccontextmanager_async(synchronizer):
+    r = synchronizer.create_async(Resource)()
     assert r.get_state() == "none"
     async with r.wrap():
         assert r.get_state() == "entered"
@@ -60,8 +57,8 @@ async def test_asynccontextmanager_async():
 
 
 @pytest.mark.asyncio
-async def test_asynccontextmanager_async_raise():
-    r = s.create_async(Resource)()
+async def test_asynccontextmanager_async_raise(synchronizer):
+    r = synchronizer.create_async(Resource)()
     assert r.get_state() == "none"
     with pytest.raises(Exception):
         async with r.wrap():
@@ -71,27 +68,26 @@ async def test_asynccontextmanager_async_raise():
 
 
 @pytest.mark.asyncio
-async def test_asynccontextmanager_yield_twice():
-    r = s.create_async(Resource)()
+async def test_asynccontextmanager_yield_twice(synchronizer):
+    r = synchronizer.create_async(Resource)()
     with pytest.raises(RuntimeError):
         async with r.wrap_yield_twice():
             pass
 
 
 @pytest.mark.asyncio
-async def test_asynccontextmanager_never_yield():
-    r = s.create_async(Resource)()
+async def test_asynccontextmanager_never_yield(synchronizer):
+    r = synchronizer.create_async(Resource)()
     with pytest.raises(RuntimeError):
         async with r.wrap_never_yield():
             pass
 
 
 @pytest.mark.asyncio
-async def test_asynccontextmanager_nested():
-    s = Synchronizer()
+async def test_asynccontextmanager_nested(synchronizer):
     finally_blocks = []
 
-    @s.create_async
+    @synchronizer.create_async
     @asynccontextmanager
     async def a():
         try:
@@ -99,7 +95,7 @@ async def test_asynccontextmanager_nested():
         finally:
             finally_blocks.append("A")
 
-    @s.create_async
+    @synchronizer.create_async
     @asynccontextmanager
     async def b():
         async with a() as it:
@@ -116,8 +112,8 @@ async def test_asynccontextmanager_nested():
 
 
 @pytest.mark.asyncio
-async def test_asynccontextmanager_with_in_async():
-    r = s.create_async(Resource)()
+async def test_asynccontextmanager_with_in_async(synchronizer):
+    r = synchronizer.create_async(Resource)()
     err_cls = AttributeError if sys.version_info < (3, 11) else TypeError
     with pytest.raises(err_cls):
         with r.wrap():

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -2,8 +2,6 @@ import pytest
 import sys
 from contextlib import asynccontextmanager
 
-from synchronicity import Synchronizer
-
 
 async def noop():
     pass

--- a/test/callback_test.py
+++ b/test/callback_test.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 import time
 
-from synchronicity import Interface, Synchronizer
+from synchronicity import Interface
 
 
 def sleep(ms):
@@ -16,9 +16,8 @@ async def sleep_async(ms):
 
 
 @pytest.mark.asyncio
-async def test_blocking():
-    s = Synchronizer()
-    sleep_cb = s.create_callback(sleep, Interface.BLOCKING)
+async def test_blocking(synchronizer):
+    sleep_cb = synchronizer.create_callback(sleep, Interface.BLOCKING)
     t0 = time.time()
     coros = [sleep_cb(200), sleep_cb(300)]
     rets = await asyncio.gather(*coros)
@@ -27,9 +26,8 @@ async def test_blocking():
 
 
 @pytest.mark.asyncio
-async def test_async():
-    s = Synchronizer()
-    sleep_cb = s.create_callback(sleep_async, Interface.ASYNC)
+async def test_async(synchronizer):
+    sleep_cb = synchronizer.create_callback(sleep_async, Interface.ASYNC)
     t0 = time.time()
     coros = [sleep_cb(200), sleep_cb(300)]
     rets = await asyncio.gather(*coros)
@@ -38,8 +36,7 @@ async def test_async():
 
 
 @pytest.mark.asyncio
-async def test_translate():
-    s = Synchronizer()
+async def test_translate(synchronizer):
 
     class Foo:
         def __init__(self, x):
@@ -48,14 +45,14 @@ async def test_translate():
         def get(self):
             return self.x
 
-    BlockingFoo = s.create_blocking(Foo)
+    BlockingFoo = synchronizer.create_blocking(Foo)
 
     def f(foo):
         assert isinstance(foo, BlockingFoo)
         x = foo.get()
         return BlockingFoo(x + 1)
 
-    f_cb = s.create_callback(f, Interface.BLOCKING)
+    f_cb = synchronizer.create_callback(f, Interface.BLOCKING)
 
     foo1 = Foo(42)
     foo2 = await f_cb(foo1)

--- a/test/callback_test.py
+++ b/test/callback_test.py
@@ -37,7 +37,6 @@ async def test_async(synchronizer):
 
 @pytest.mark.asyncio
 async def test_translate(synchronizer):
-
     class Foo:
         def __init__(self, x):
             self.x = x

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from synchronicity import Synchronizer
+
+
+@pytest.fixture()
+def synchronizer():
+    s = Synchronizer()
+    yield s
+    s._close_loop()  # avoid "unclosed event loop" warnings in tests when garbage collecting synchronizers

--- a/test/docstring_test.py
+++ b/test/docstring_test.py
@@ -1,9 +1,7 @@
 from synchronicity import Synchronizer
 
 
-def test_docs():
-    s = Synchronizer()
-
+def test_docs(synchronizer):
     class Foo:
         def __init__(self):
             """init docs"""
@@ -16,12 +14,12 @@ def test_docs():
     assert foo.__init__.__doc__ == "init docs"
     assert foo.bar.__doc__ == "bar docs"
 
-    BlockingFoo = s.create_blocking(Foo)
+    BlockingFoo = synchronizer.create_blocking(Foo)
     blocking_foo = BlockingFoo()
     assert blocking_foo.__init__.__doc__ == "init docs"
     assert blocking_foo.bar.__doc__ == "bar docs"
 
-    AsyncFoo = s.create_async(Foo)
+    AsyncFoo = synchronizer.create_async(Foo)
     async_foo = AsyncFoo()
     assert async_foo.__init__.__doc__ == "init docs"
     assert async_foo.bar.__doc__ == "bar docs"

--- a/test/docstring_test.py
+++ b/test/docstring_test.py
@@ -1,4 +1,3 @@
-from synchronicity import Synchronizer
 
 
 def test_docs(synchronizer):

--- a/test/exception_test.py
+++ b/test/exception_test.py
@@ -4,7 +4,6 @@ import inspect
 import pytest
 import time
 
-from synchronicity import Synchronizer
 
 SLEEP_DELAY = 0.1
 
@@ -18,19 +17,17 @@ async def f_raises():
     raise CustomException("something failed")
 
 
-def test_function_raises_sync():
-    s = Synchronizer()
+def test_function_raises_sync(synchronizer):
     t0 = time.time()
     with pytest.raises(CustomException):
-        f_raises_s = s.create_blocking(f_raises)
+        f_raises_s = synchronizer.create_blocking(f_raises)
         f_raises_s()
     assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
 
 
-def test_function_raises_sync_futures():
-    s = Synchronizer()
+def test_function_raises_sync_futures(synchronizer):
     t0 = time.time()
-    f_raises_s = s.create_blocking(f_raises)
+    f_raises_s = synchronizer.create_blocking(f_raises)
     fut = f_raises_s(_future=True)
     assert isinstance(fut, concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
@@ -40,10 +37,9 @@ def test_function_raises_sync_futures():
 
 
 @pytest.mark.asyncio
-async def test_function_raises_async():
-    s = Synchronizer()
+async def test_function_raises_async(synchronizer):
     t0 = time.time()
-    f_raises_s = s.create_async(f_raises)
+    f_raises_s = synchronizer.create_async(f_raises)
     coro = f_raises_s()
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY
@@ -57,11 +53,10 @@ async def f_raises_baseexc():
     raise KeyboardInterrupt
 
 
-def test_function_raises_baseexc_sync():
-    s = Synchronizer()
+def test_function_raises_baseexc_sync(synchronizer):
     t0 = time.time()
     with pytest.raises(BaseException):
-        f_raises_baseexc_s = s.create_blocking(f_raises_baseexc)
+        f_raises_baseexc_s = synchronizer.create_blocking(f_raises_baseexc)
         f_raises_baseexc_s()
     assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
 
@@ -71,10 +66,9 @@ def f_raises_syncwrap():
 
 
 @pytest.mark.asyncio
-async def test_function_raises_async_syncwrap():
-    s = Synchronizer()
+async def test_function_raises_async_syncwrap(synchronizer):
     t0 = time.time()
-    f_raises_syncwrap_s = s.create_async(f_raises_syncwrap)
+    f_raises_syncwrap_s = synchronizer.create_async(f_raises_syncwrap)
     coro = f_raises_syncwrap_s()
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY

--- a/test/exception_test.py
+++ b/test/exception_test.py
@@ -4,7 +4,6 @@ import inspect
 import pytest
 import time
 
-
 SLEEP_DELAY = 0.1
 
 

--- a/test/generators_test.py
+++ b/test/generators_test.py
@@ -1,8 +1,6 @@
 import asyncio
 import pytest
 
-from synchronicity import Synchronizer
-
 events = []
 
 

--- a/test/getattr_test.py
+++ b/test/getattr_test.py
@@ -2,8 +2,6 @@ import asyncio
 import pytest
 from typing import Any, Dict
 
-from synchronicity import Synchronizer
-
 
 def test_getattr(synchronizer):
     class Foo:

--- a/test/getattr_test.py
+++ b/test/getattr_test.py
@@ -6,7 +6,6 @@ from synchronicity import Synchronizer
 
 
 def test_getattr(synchronizer):
-
     class Foo:
         _attrs: Dict[str, Any]
 

--- a/test/getattr_test.py
+++ b/test/getattr_test.py
@@ -5,8 +5,7 @@ from typing import Any, Dict
 from synchronicity import Synchronizer
 
 
-def test_getattr():
-    s = Synchronizer()
+def test_getattr(synchronizer):
 
     class Foo:
         _attrs: Dict[str, Any]
@@ -40,7 +39,7 @@ def test_getattr():
         asyncio.run(foo.y)
     assert foo.z == 42
 
-    BlockingFoo = s.create_blocking(Foo)
+    BlockingFoo = synchronizer.create_blocking(Foo)
 
     blocking_foo = BlockingFoo()
     blocking_foo.x = 42
@@ -52,7 +51,7 @@ def test_getattr():
     blocking_foo = BlockingFoo.make_foo()
     assert isinstance(blocking_foo, BlockingFoo)
 
-    AsyncFoo = s.create_async(Foo)
+    AsyncFoo = synchronizer.create_async(Foo)
     async_foo = AsyncFoo()
     async_foo.x = 42
     assert asyncio.run(async_foo.x) == 42

--- a/test/mark_test.py
+++ b/test/mark_test.py
@@ -1,11 +1,10 @@
 from synchronicity import Synchronizer
 
 
-def test_function_sync():
-    s = Synchronizer()
+def test_function_sync(synchronizer):
 
     async def f(x):
         return x**2
 
-    f_blocking = s.create_blocking(f)
+    f_blocking = synchronizer.create_blocking(f)
     assert f_blocking(42) == 1764

--- a/test/mark_test.py
+++ b/test/mark_test.py
@@ -2,7 +2,6 @@ from synchronicity import Synchronizer
 
 
 def test_function_sync(synchronizer):
-
     async def f(x):
         return x**2
 

--- a/test/mark_test.py
+++ b/test/mark_test.py
@@ -1,4 +1,3 @@
-from synchronicity import Synchronizer
 
 
 def test_function_sync(synchronizer):

--- a/test/mark_test.py
+++ b/test/mark_test.py
@@ -1,5 +1,3 @@
-
-
 def test_function_sync(synchronizer):
     async def f(x):
         return x**2

--- a/test/pickle_test.py
+++ b/test/pickle_test.py
@@ -1,7 +1,7 @@
 import pickle
 import pytest
 
-from synchronicity import Interface, Synchronizer
+from synchronicity import Interface
 
 
 class PicklableClass:

--- a/test/pickle_test.py
+++ b/test/pickle_test.py
@@ -10,9 +10,8 @@ class PicklableClass:
 
 
 @pytest.mark.skip(reason="Let's revisit this in 0.2.0")
-def test_pickle():
-    s = Synchronizer()
-    BlockingPicklableClass = s.create(PicklableClass, Interface.BLOCKING)
+def test_pickle(synchronizer):
+    BlockingPicklableClass = synchronizer.create(PicklableClass, Interface.BLOCKING)
     obj = BlockingPicklableClass()
     assert obj.f(42) == 1764
     data = pickle.dumps(obj)
@@ -20,6 +19,5 @@ def test_pickle():
     assert obj2.f(43) == 1849
 
 
-def test_pickle_synchronizer():
-    s = Synchronizer()
-    pickle.dumps(s)
+def test_pickle_synchronizer(synchronizer):
+    pickle.dumps(synchronizer)

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -1,13 +1,16 @@
 import asyncio
 import concurrent.futures
 import inspect
+import typing
+
 import pytest
 import time
 from typing import Coroutine
 from unittest.mock import MagicMock
 
+import synchronicity
 from synchronicity import Interface, Synchronizer
-
+import typing
 SLEEP_DELAY = 0.1
 
 
@@ -566,3 +569,19 @@ async def test_non_async_aiter():
     it = WrappedIt()
     assert list(it) == ["foo", "bar"]
 
+
+def test_generic_baseclass():
+    class Foo:
+        pass
+
+    T = typing.TypeVar("T")
+
+    class GenericClass(typing.Generic[T], Foo):
+        async def do_something(self):
+            return 1
+
+    s = synchronicity.Synchronizer()
+    WrappedGenericClass = s.create_blocking(GenericClass, name="BlockingGenericClass")
+    instance: WrappedGenericClass[str] = WrappedGenericClass()  #  should be allowed
+    assert isinstance(instance, WrappedGenericClass)
+    assert instance.do_something() == 1

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -571,12 +571,9 @@ async def test_non_async_aiter():
 
 
 def test_generic_baseclass():
-    class Foo:
-        pass
-
     T = typing.TypeVar("T")
 
-    class GenericClass(typing.Generic[T], Foo):
+    class GenericClass(typing.Generic[T]):
         async def do_something(self):
             return 1
 

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -189,7 +189,6 @@ async def test_generator_async(synchronizer):
 
 @pytest.mark.asyncio
 async def test_function_returning_coroutine(synchronizer):
-
     def func() -> Coroutine:
         async def inner():
             return 10
@@ -458,7 +457,6 @@ def test_set_class_name(synchronizer):
 
 @pytest.mark.asyncio
 async def test_blocking_nested_aio_returns_blocking_obj(synchronizer):
-
     class Foo:
         async def get_self(self):
             return self
@@ -494,7 +492,6 @@ def test_no_input_translation(monkeypatch, synchronizer):
 
 
 def test_no_output_translation(monkeypatch, synchronizer):
-
     @synchronizer.create_blocking
     def does_output_translation(arg: float) -> str:
         return str(arg)

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import synchronicity
 from synchronicity import Interface, Synchronizer
-import typing
+
 SLEEP_DELAY = 0.1
 
 
@@ -577,7 +577,7 @@ def test_generic_baseclass():
         async def do_something(self):
             return 1
 
-    s = synchronicity.Synchronizer()
+    s = synchronicity.Synchronizer(multiwrap_warning=False)
     WrappedGenericClass = s.create_blocking(GenericClass, name="BlockingGenericClass")
     instance: WrappedGenericClass[str] = WrappedGenericClass()  #  should be allowed
     assert isinstance(instance, WrappedGenericClass)

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -1,10 +1,9 @@
 import asyncio
 import concurrent.futures
 import inspect
-import typing
-
 import pytest
 import time
+import typing
 from typing import Coroutine
 from unittest.mock import MagicMock
 

--- a/test/threading_test.py
+++ b/test/threading_test.py
@@ -2,8 +2,6 @@ import asyncio
 import concurrent.futures
 import time
 
-from synchronicity import Synchronizer
-
 
 def test_start_loop(synchronizer):
     # Make sure there's no race condition in _start_loop

--- a/test/threading_test.py
+++ b/test/threading_test.py
@@ -5,12 +5,10 @@ import time
 from synchronicity import Synchronizer
 
 
-def test_start_loop():
+def test_start_loop(synchronizer):
     # Make sure there's no race condition in _start_loop
-    s = Synchronizer()
-
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        ret = list(executor.map(lambda i: s._start_loop(), range(1000)))
+        ret = list(executor.map(lambda i: synchronizer._start_loop(), range(1000)))
 
     assert len(set(ret)) == 1
     assert isinstance(ret[0], asyncio.AbstractEventLoop)
@@ -21,10 +19,8 @@ async def f(i):
     return i**2
 
 
-def test_multithreaded(n_threads=20):
-    s = Synchronizer()
-
-    f_s = s.create_blocking(f)
+def test_multithreaded(synchronizer, n_threads=20):
+    f_s = synchronizer.create_blocking(f)
 
     t0 = time.time()
     with concurrent.futures.ThreadPoolExecutor(max_workers=n_threads) as executor:

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -1,8 +1,6 @@
 import pytest
 import traceback
 
-from synchronicity import Synchronizer
-
 
 class CustomException(Exception):
     pass
@@ -44,17 +42,15 @@ def test_sync_to_async(synchronizer):
 
 
 @pytest.mark.asyncio
-async def test_async_to_async():
-    s = Synchronizer()
-    f_s = s.create_async(f)
+async def test_async_to_async(synchronizer):
+    f_s = synchronizer.create_async(f)
     with pytest.raises(CustomException) as excinfo:
         await f_s()
     check_traceback(excinfo.value)
 
 
-def test_sync_to_async_gen():
-    s = Synchronizer()
-    gen_s = s.create_blocking(gen)
+def test_sync_to_async_gen(synchronizer):
+    gen_s = synchronizer.create_blocking(gen)
     with pytest.raises(CustomException) as excinfo:
         for x in gen_s():
             pass
@@ -62,9 +58,8 @@ def test_sync_to_async_gen():
 
 
 @pytest.mark.asyncio
-async def test_async_to_async_gen():
-    s = Synchronizer()
-    gen_s = s.create_async(gen)
+async def test_async_to_async_gen(synchronizer):
+    gen_s = synchronizer.create_async(gen)
     with pytest.raises(CustomException) as excinfo:
         async for x in gen_s():
             pass
@@ -72,9 +67,8 @@ async def test_async_to_async_gen():
 
 
 @pytest.mark.skip(reason="This one will be much easier to fix once AUTODETECT is gone")
-def test_sync_to_async_ctx_mgr():
-    s = Synchronizer()
-    ctx_mgr = s.create_blocking(s.asynccontextmanager(gen))
+def test_sync_to_async_ctx_mgr(synchronizer):
+    ctx_mgr = synchronizer.create_blocking(synchronizer.asynccontextmanager(gen))
     with pytest.raises(CustomException) as excinfo:
         with ctx_mgr():
             pass

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -36,9 +36,8 @@ def check_traceback(exc):
         raise Exception(f"Got {n_outside} frames outside user code, expected 1")
 
 
-def test_sync_to_async():
-    s = Synchronizer()
-    f_s = s.create_blocking(f)
+def test_sync_to_async(synchronizer):
+    f_s = synchronizer.create_blocking(f)
     with pytest.raises(CustomException) as excinfo:
         f_s()
     check_traceback(excinfo.value)
@@ -84,17 +83,15 @@ def test_sync_to_async_ctx_mgr():
 
 @pytest.mark.skip(reason="This one will be much easier to fix once AUTODETECT is gone")
 @pytest.mark.asyncio
-async def test_async_to_async_ctx_mgr():
-    s = Synchronizer()
-    ctx_mgr = s.create_async(s.asynccontextmanager(gen))
+async def test_async_to_async_ctx_mgr(synchronizer):
+    ctx_mgr = synchronizer.create_async(synchronizer.asynccontextmanager(gen))
     with pytest.raises(CustomException) as excinfo:
         async with ctx_mgr():
             pass
     check_traceback(excinfo.value)
 
 
-def test_recursive():
-    s = Synchronizer()
+def test_recursive(synchronizer):
 
     async def f(n):
         if n == 0:
@@ -103,6 +100,6 @@ def test_recursive():
             return await f(n - 1)
 
     with pytest.raises(CustomException) as excinfo:
-        f_blocking = s.create_blocking(f)
+        f_blocking = synchronizer.create_blocking(f)
         f_blocking(10)
     check_traceback(excinfo.value)

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -92,7 +92,6 @@ async def test_async_to_async_ctx_mgr(synchronizer):
 
 
 def test_recursive(synchronizer):
-
     async def f(n):
         if n == 0:
             raise CustomException("boom!")

--- a/test/translate_test.py
+++ b/test/translate_test.py
@@ -1,8 +1,7 @@
 from synchronicity import Synchronizer
 
 
-def test_translate():
-    s = Synchronizer()
+def test_translate(synchronizer):
 
     class Foo:
         pass
@@ -37,9 +36,9 @@ def test_translate():
         def cls_out(cls):
             return FooProvider
 
-    BlockingFoo = s.create_blocking(Foo)
+    BlockingFoo = synchronizer.create_blocking(Foo)
     assert BlockingFoo.__name__ == "BlockingFoo"
-    BlockingFooProvider = s.create_blocking(FooProvider)
+    BlockingFooProvider = synchronizer.create_blocking(FooProvider)
     assert BlockingFooProvider.__name__ == "BlockingFooProvider"
     foo_provider = BlockingFooProvider()
 

--- a/test/translate_test.py
+++ b/test/translate_test.py
@@ -1,8 +1,4 @@
-from synchronicity import Synchronizer
-
-
 def test_translate(synchronizer):
-
     class Foo:
         pass
 

--- a/test/type_stub_e2e_test.py
+++ b/test/type_stub_e2e_test.py
@@ -1,7 +1,6 @@
-import sys
-
 import pytest
 import subprocess
+import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path

--- a/test/type_stub_e2e_test.py
+++ b/test/type_stub_e2e_test.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import subprocess
 import tempfile
@@ -16,11 +18,14 @@ class FailedMyPyCheck(Exception):
         self.output = output
 
 
-def run_mypy(input_file):
+def run_mypy(input_file, print_errors=True):
     p = subprocess.Popen(["mypy", input_file], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
     result_code = p.wait()
     if result_code != 0:
-        raise FailedMyPyCheck(p.stdout.read())
+        mypy_report = p.stdout.read().decode("utf8")
+        if print_errors:
+            print(mypy_report, file=sys.stderr)
+        raise FailedMyPyCheck(mypy_report)
 
 
 @contextmanager
@@ -75,4 +80,4 @@ def test_failing_assertion(interface_file, failing_assertion, error_matches):
     # we use the assertion file as a template to insert statements that should fail type checking
     with temp_assertion_file(failing_assertion) as custom_file:  # we pass int instead of str
         with pytest.raises(FailedMyPyCheck, match=error_matches):
-            run_mypy(custom_file)
+            run_mypy(custom_file, print_errors=False)

--- a/test/type_stub_helpers/e2e_example_export.py
+++ b/test/type_stub_helpers/e2e_example_export.py
@@ -22,9 +22,9 @@ returns_foo = synchronizer.create_blocking(e2e_example_impl._returns_foo, "retur
 
 wrapped_make_context = synchronizer.create_blocking(e2e_example_impl.make_context, "make_context", __name__)
 
-P = synchronizer.create_blocking(e2e_example_impl.P, "P", __name__)  # TODO: these shouldn't be needed/automate creation of these?
-
-R = synchronizer.create_blocking(e2e_example_impl.R, "R", __name__)  # TODO: these shouldn't be needed/automate creation of these?
+# TODO: we shouldn't need to wrap typevars unless they have wrapped `bounds`
+P = synchronizer.create_blocking(e2e_example_impl.P, "P", __name__)
+R = synchronizer.create_blocking(e2e_example_impl.R, "R", __name__)
 
 
 CallableWrapper = synchronizer.create_blocking(e2e_example_impl.CallableWrapper, "CallableWrapper", __name__)

--- a/test/type_stub_helpers/e2e_example_export.py
+++ b/test/type_stub_helpers/e2e_example_export.py
@@ -21,3 +21,12 @@ overloaded = synchronizer.create_blocking(e2e_example_impl._overloaded, "overloa
 returns_foo = synchronizer.create_blocking(e2e_example_impl._returns_foo, "returns_foo", __name__)
 
 wrapped_make_context = synchronizer.create_blocking(e2e_example_impl.make_context, "make_context", __name__)
+
+P = synchronizer.create_blocking(e2e_example_impl.P, "P", __name__)  # TODO: these shouldn't be needed/automate creation of these?
+
+R = synchronizer.create_blocking(e2e_example_impl.R, "R", __name__)  # TODO: these shouldn't be needed/automate creation of these?
+
+
+CallableWrapper = synchronizer.create_blocking(e2e_example_impl.CallableWrapper, "CallableWrapper", __name__)
+
+wrap_callable = synchronizer.create_blocking(e2e_example_impl.wrap_callable, "wrap_callable", __name__)

--- a/test/type_stub_helpers/e2e_example_impl.py
+++ b/test/type_stub_helpers/e2e_example_impl.py
@@ -63,7 +63,7 @@ R = typing.TypeVar("R")
 
 
 class CallableWrapper(typing.Generic[P, R]):
-    def func(self, *args: P.args, **kwargs: P.kwargs) -> R:
+    async def func(self, *args: P.args, **kwargs: P.kwargs) -> R:
         return  # type: ignore
 
 def wrap_callable(c: typing.Callable[P, R]) -> CallableWrapper[P, R]:

--- a/test/type_stub_helpers/e2e_example_impl.py
+++ b/test/type_stub_helpers/e2e_example_impl.py
@@ -1,4 +1,5 @@
 import typing
+import typing_extensions
 from typing import AsyncGenerator, List, TypeVar, Union, overload
 
 from synchronicity.async_wrap import asynccontextmanager
@@ -18,11 +19,11 @@ class _Foo:
 
     @staticmethod
     def some_static(arg: str) -> float:
-        ...
+        return  # type: ignore
 
     @classmethod
     def clone(cls, foo: "_Foo") -> "_Foo":  # self ref
-        ...
+        return  # type: ignore
 
 
 _T = TypeVar("_T", bound=_Foo)
@@ -55,3 +56,15 @@ async def _returns_foo() -> _Foo:
 @asynccontextmanager
 async def make_context(a: float) -> typing.AsyncGenerator[str, None]:
     yield "hello"
+
+
+P = typing_extensions.ParamSpec("P")
+R = typing.TypeVar("R")
+
+
+class CallableWrapper(typing.Generic[P, R]):
+    def func(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        return  # type: ignore
+
+def wrap_callable(c: typing.Callable[P, R]) -> CallableWrapper[P, R]:
+    return  # type: ignore

--- a/test/type_stub_helpers/e2e_example_impl.py
+++ b/test/type_stub_helpers/e2e_example_impl.py
@@ -1,6 +1,7 @@
 import typing
-import typing_extensions
 from typing import AsyncGenerator, List, TypeVar, Union, overload
+
+import typing_extensions
 
 from synchronicity.async_wrap import asynccontextmanager
 

--- a/test/type_stub_helpers/e2e_example_impl.py
+++ b/test/type_stub_helpers/e2e_example_impl.py
@@ -67,5 +67,6 @@ class CallableWrapper(typing.Generic[P, R]):
     async def func(self, *args: P.args, **kwargs: P.kwargs) -> R:
         return  # type: ignore
 
+
 def wrap_callable(c: typing.Callable[P, R]) -> CallableWrapper[P, R]:
     return  # type: ignore

--- a/test/type_stub_helpers/e2e_example_type_assertions.py
+++ b/test/type_stub_helpers/e2e_example_type_assertions.py
@@ -46,3 +46,10 @@ async def async_block() -> None:
     # not sure if this should actually be supported, but it is, for completeness:
     async with e2e_example_export.wrapped_make_context.aio(10.0) as c:
         assert_type(c, str)
+
+
+def f(a: str) -> float:
+    return 0.1
+
+res = e2e_example_export.wrap_callable(f).func(a="q")
+assert_type(res, float)

--- a/test/type_stub_helpers/e2e_example_type_assertions.py
+++ b/test/type_stub_helpers/e2e_example_type_assertions.py
@@ -51,5 +51,6 @@ async def async_block() -> None:
 def f(a: str) -> float:
     return 0.1
 
+
 res = e2e_example_export.wrap_callable(f).func(a="q")
 assert_type(res, float)

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -544,21 +544,24 @@ def test_collections_iterator():
 
 
 U = typing.TypeVar("U")
+
+
 class _ReturnVal(typing.Generic[U]):
     pass
 
+
 ReturnVal = synchronizer.create_blocking(_ReturnVal, "ReturnVal", __name__)
+
 
 def test_returns_forward_wrapped_generic():
     # forward reference of a wrapped generic as a string is one of the trickier cases to handle
-    # as the string needs to be evaluated, the generics need to be recursively expanded and 
+    # as the string needs to be evaluated, the generics need to be recursively expanded and
     # type vars need to be replaced with "inner" generated versions
 
     class _Container(typing.Generic[T]):
         async def fun(self) -> "ReturnVal[T]":
             return ReturnVal()
 
-        
     Container = synchronizer.create_blocking(_Container, "Container")
 
     src = _class_source(Container)

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -559,7 +559,13 @@ def test_returns_forward_wrapped_generic():
             return ReturnVal()
 
         
-    Container = synchronizer.create_blocking(_Container)
+    Container = synchronizer.create_blocking(_Container, "Container")
 
     src = _class_source(Container)
-    print(src)
+
+    # base class should be generic in the (potentially) translated type var (could have wrapped bounds spec)
+    assert "class Container(typing.Generic[Translated_T]):" in src
+    assert "Translated_T_INNER = typing.TypeVar" in src  # distinct "inner copy" of Translated_T needs to be declared
+    assert "typing_extensions.Protocol[Translated_T_INNER]" in src
+    assert "def __call__(self) -> ReturnVal[Translated_T_INNER]:" in src
+    assert "fun: __fun_spec[Translated_T]" in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -526,3 +526,25 @@ def test_collections_iterator():
 
     src = _function_source(foo)
     assert "-> collections.abc.Iterator[int]" in src
+
+
+U = typing.TypeVar("U")
+class _ReturnVal(typing.Generic[U]):
+    pass
+
+ReturnVal = synchronizer.create_blocking(_ReturnVal, "ReturnVal", __name__)
+
+def test_returns_forward_wrapped_generic():
+    # forward reference of a wrapped generic as a string is one of the trickier cases to handle
+    # as the string needs to be evaluated, the generics need to be recursively expanded and 
+    # type vars need to be replaced with "inner" generated versions
+
+    class _Container(typing.Generic[T]):
+        async def fun(self) -> "ReturnVal[T]":
+            return ReturnVal()
+
+        
+    Container = synchronizer.create_blocking(_Container)
+
+    src = _class_source(Container)
+    print(src)

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -331,11 +331,13 @@ Translated_P = synchronizer.create_blocking(P, "Translated_P", __name__)
 class MyGeneric(typing.Generic[T]):
     ...
 
+
 BlockingMyGeneric = synchronizer.create_blocking(
     MyGeneric,
     "BlockingMyGeneric",
     __name__,
 )
+
 
 def test_custom_generic():
     # TODO: build out this test a bit, as it currently creates an invalid stub (missing base types)
@@ -356,11 +358,7 @@ class ParamSpecGeneric(typing.Generic[P, T]):
         ...
 
 
-BlockingParamSpecGeneric = synchronizer.create_blocking(
-    ParamSpecGeneric,
-    "BlockingParamSpecGeneric",
-    __name__
-)
+BlockingParamSpecGeneric = synchronizer.create_blocking(ParamSpecGeneric, "BlockingParamSpecGeneric", __name__)
 
 
 def test_paramspec_generic():
@@ -372,6 +370,7 @@ def test_paramspec_generic():
     assert "def aio(self, *args: Translated_P_INNER.args, **kwargs: Translated_P_INNER.kwargs)" in src
     assert "meth: __meth_spec[Translated_P]" in src
     assert "def syncfunc(self) -> Translated_T:" in src
+
 
 def test_synchronicity_generic_subclass():
     class Specific(MyGeneric[str]):
@@ -456,12 +455,12 @@ def test_ellipsis():
 
 def test_param_spec():
     P = typing_extensions.ParamSpec("P")
+
     def foo() -> typing.Callable[P, typing.Any]:
         return lambda x: 0
 
     src = _function_source(foo)
     assert "-> typing.Callable[P, typing.Any]" in src
-
 
 
 def test_typing_literal():

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -347,7 +347,11 @@ def test_custom_generic():
 
 
 class ParamSpecGeneric(typing.Generic[P, T]):
-    ...
+    async def meth(self, *args: P.args, **kwargs: P.kwargs):
+        ...
+
+    def syncfunc(self) -> T:
+        ...
 
 
 BlockingParamSpecGeneric = synchronizer.create_blocking(
@@ -361,6 +365,11 @@ def test_paramspec_generic():
     src = _class_source(BlockingParamSpecGeneric)
     assert "class BlockingParamSpecGeneric(typing.Generic[Translated_P, Translated_T])" in src
 
+    assert "class __meth_spec(typing_extensions.Protocol[Translated_P_INNER]):" in src
+    assert "def __call__(self, *args: Translated_P_INNER.args, **kwargs: Translated_P_INNER.kwargs)" in src
+    assert "def aio(self, *args: Translated_P_INNER.args, **kwargs: Translated_P_INNER.kwargs)" in src
+    assert "meth: __meth_spec[Translated_P]" in src
+    assert "def syncfunc(self) -> Translated_T:" in src
 
 def test_synchronicity_generic_subclass():
     class Specific(MyGeneric[str]):

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -12,7 +12,7 @@ from synchronicity.async_wrap import asynccontextmanager
 from synchronicity.type_stubs import StubEmitter
 
 from .type_stub_helpers import some_mod
-
+import typing_extensions
 
 def noop():
     ...
@@ -319,7 +319,7 @@ def test_synchronicity_class():
 
 
 T = typing.TypeVar("T")
-P = typing.ParamSpec("P")
+P = typing_extensions.ParamSpec("P")
 
 
 Translated_T = synchronizer.create_blocking(T, "Translated_T", __name__)
@@ -453,7 +453,7 @@ def test_ellipsis():
 
 
 def test_param_spec():
-    P = typing.ParamSpec("P")
+    P = typing_extensions.ParamSpec("P")
     def foo() -> typing.Callable[P, typing.Any]:
         return lambda x: 0
 

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -436,6 +436,14 @@ def test_literal_alias(tmp_path):
     assert "bar = typing.Literal['bar']" in src
 
 
+def test_callable():
+    def foo() -> typing.Callable[[str], float]:
+        return lambda x: 0.0
+
+    src = _function_source(foo)
+    assert "-> typing.Callable[[str], float]" in src
+
+
 def test_ellipsis():
     def foo() -> typing.Callable[..., typing.Any]:
         return lambda x: 0

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -6,13 +6,15 @@ import sys
 import typing
 from textwrap import dedent
 
+import typing_extensions
+
 import synchronicity
 from synchronicity import overload_tracking
 from synchronicity.async_wrap import asynccontextmanager
 from synchronicity.type_stubs import StubEmitter
 
 from .type_stub_helpers import some_mod
-import typing_extensions
+
 
 def noop():
     ...

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -44,4 +44,4 @@ def test_check_double_wrapped(recwarn, synchronizer):
     assert len(recwarn) == 1
 
     for w in recwarn.list:
-        print(w)
+        print("Recorded warning:", w)

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -42,3 +42,6 @@ def test_check_double_wrapped(recwarn, synchronizer):
     ret = synchronizer.create_blocking(returns_asyncgen)()
     assert inspect.isasyncgen(ret)
     assert len(recwarn) == 1
+
+    for w in recwarn.list:
+        print(w)

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -23,7 +23,9 @@ def test_multiwrap_no_warning(recwarn):
     assert f_s(42) == 1764
     f_s_s = s.create_blocking(f_s)
     assert f_s_s(42) == 1764
-    print(recwarn.list)  # DEBUG
+    print("Recorded warnings:")
+    for w in recwarn.list:
+        print(str(w))
     assert len(recwarn) == 0
 
 

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -15,13 +15,13 @@ def test_multiwrap_warning(recwarn):
     f_s_s = s.create_blocking(f_s)
     assert f_s_s(42) == 1764
     assert len(recwarn) == 1
+    s._close_loop()  # clean up
 
 
-def test_multiwrap_no_warning(recwarn):
-    s = Synchronizer()
-    f_s = s.create_blocking(f)
+def test_multiwrap_no_warning(recwarn, synchronizer):
+    f_s = synchronizer.create_blocking(f)
     assert f_s(42) == 1764
-    f_s_s = s.create_blocking(f_s)
+    f_s_s = synchronizer.create_blocking(f_s)
     assert f_s_s(42) == 1764
     print("Recorded warnings:")
     for w in recwarn.list:
@@ -37,9 +37,8 @@ async def returns_asyncgen():
     return asyncgen()
 
 
-def test_check_double_wrapped(recwarn):
-    s = Synchronizer()
+def test_check_double_wrapped(recwarn, synchronizer):
     assert len(recwarn) == 0
-    ret = s.create_blocking(returns_asyncgen)()
+    ret = synchronizer.create_blocking(returns_asyncgen)()
     assert inspect.isasyncgen(ret)
     assert len(recwarn) == 1

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -41,7 +41,7 @@ def test_check_double_wrapped(recwarn, synchronizer):
     assert len(recwarn) == 0
     ret = synchronizer.create_blocking(returns_asyncgen)()
     assert inspect.isasyncgen(ret)
-    assert len(recwarn) == 1
-
     for w in recwarn.list:
         print("Recorded warning:", w)
+
+    assert len(recwarn) == 1

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -23,6 +23,7 @@ def test_multiwrap_no_warning(recwarn):
     assert f_s(42) == 1764
     f_s_s = s.create_blocking(f_s)
     assert f_s_s(42) == 1764
+    print(recwarn.list)  # DEBUG
     assert len(recwarn) == 0
 
 


### PR DESCRIPTION
TLDR: this will allow Modal's `func.remote(...)` and `func.remote.aio(...)` to autocomplete the arguments and return types of the underlying function wrapped by `@app.function`

## Details:
A little bit of 🍝 code to get `Generic` typevars/paramspecs properly forwarded to the inner Protocols used for wrapped async methods, resulting in the type stub for this class:
```py
T = TypeVar("T")
class Foo(Generic[T]):
     def method(self, t: T):
         ...
```

Resulting in code similar to this:
```py
T = TypeVar("T")
T_INNER = TypeVar("T_INNER")
class Foo(Generic[T]):
    class MethodProtocol(typing.Protocol[T_INNER]):
        def __call__(self, t: T_INNER):
            ...
        def aio(self, t: T_INNER):
            ...

    method: MethodProtocol[T]
```