### PR TITLE
Release v0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.6.8"
+version = "0.7.0"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,10 @@
 [project]
 name = "synchronicity"
-version = "0.6.7"
+version = "0.6.8"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 
-dependencies = [
-    "sigtools==4.0.1",
-    "typing_extensions>=4.6",
-]
+dependencies = ["sigtools==4.0.1", "typing_extensions>=4.6"]
 requires-python = ">=3.8"
 
 [build-system]
@@ -26,7 +23,5 @@ select = ['E', 'F', 'W', 'I']
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-known-first-party = [
-    "synchronicity",
-]
+known-first-party = ["synchronicity"]
 extra-standard-library = ["pytest"]


### PR DESCRIPTION
Release notes:
* Adds/improves support for typing.Generics with ParamSpec/TypeVars in type stubs for wrapped functions
* Failsafe closing event loop when synchronizer is deleted + use fixtures in tests to prevent test flake when event loop isn't shut down

Should be safe and backward compatible since it mostly changes type stub output, but to be extra safe we bump the minor version to prevent auto-upgrades of `~0.6.x` version specifications