### PR TITLE
Adds support for transferring dataclass_transform decorators to type stubs

### DIFF
--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -787,13 +787,13 @@ class StubEmitter:
             if dt_spec["field_specifiers"]:
                 refs = ""
                 for field_spec_entity in dt_spec["field_specifiers"]:
-                    if field_spec_entity.__module__ == self.target_module: 
+                    if field_spec_entity.__module__ == self.target_module:
                         ref = field_spec_entity.__qualname__
                     else:
                         self.imports.add(field_spec_entity.__module__)
                         ref = f"{field_spec_entity.__module__}.{field_spec_entity.__qualname__}"
                     refs += ref + ", "
-                    
+
                 args = f"field_specifiers=({refs})"
             maybe_decorators = f"{signature_indent}@typing_extensions.dataclass_transform({args})\n"
 

--- a/test/docstring_test.py
+++ b/test/docstring_test.py
@@ -1,5 +1,3 @@
-
-
 def test_docs(synchronizer):
     class Foo:
         def __init__(self):

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -577,14 +577,14 @@ def test_returns_forward_wrapped_generic():
 def custom_field():  # needs to be in global scope
     pass
 
+
 def test_dataclass_transform():
     @typing_extensions.dataclass_transform(field_specifiers=(custom_field,))
     def decorator():
         pass
-    
-    src = _function_source(decorator)    
-    assert "@typing_extensions.dataclass_transform(field_specifiers=(custom_field, ))\n" in src
 
+    src = _function_source(decorator)
+    assert "@typing_extensions.dataclass_transform(field_specifiers=(custom_field, ))\n" in src
 
     src = _function_source(decorator, target_module="other_module")
     assert "import test.type_stub_test" in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -572,3 +572,20 @@ def test_returns_forward_wrapped_generic():
     assert "typing_extensions.Protocol[Translated_T_INNER]" in src
     assert "def __call__(self) -> ReturnVal[Translated_T_INNER]:" in src
     assert "fun: __fun_spec[Translated_T]" in src
+
+
+def custom_field():  # needs to be in global scope
+    pass
+
+def test_dataclass_transform():
+    @typing_extensions.dataclass_transform(field_specifiers=(custom_field,))
+    def decorator():
+        pass
+    
+    src = _function_source(decorator)    
+    assert "@typing_extensions.dataclass_transform(field_specifiers=(custom_field, ))\n" in src
+
+
+    src = _function_source(decorator, target_module="other_module")
+    assert "import test.type_stub_test" in src
+    assert "@typing_extensions.dataclass_transform(field_specifiers=(test.type_stub_test.custom_field, ))\n" in src


### PR DESCRIPTION
Ensures that functions like this:
```py
@typing{_extensions}.dataclass_transform(field_specifiers=(custom_field,))
def decorator():
    ...
```
maintain their dataclass_transform decorator in a generated type stub