### PR TITLE
Type stubs: Adds support for typing_extensions.concatenate

### DIFF
--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -53,6 +53,8 @@ def safe_get_module(obj: typing.Any) -> typing.Optional[str]:
     if obj.__module__ in ("_contextvars", "_asyncio"):
         return obj.__module__[1:]  # strip leading underscore
 
+    if obj == typing_extensions.Concatenate:
+        return "typing_extensions"
     return obj.__module__
 
 

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -11,7 +11,7 @@ import typing_extensions
 import synchronicity
 from synchronicity import overload_tracking
 from synchronicity.async_wrap import asynccontextmanager
-from synchronicity.type_stubs import StubEmitter
+from synchronicity.type_stubs import StubEmitter, safe_get_module
 
 from .type_stub_helpers import some_mod
 
@@ -600,3 +600,7 @@ def test_contextvar():
     src = s.get_source()
     assert "import contextvars" in src
     assert "c: contextvars.ContextVar" in src
+
+
+def test_concatenate_origin_module():
+    assert safe_get_module(typing_extensions.Concatenate) == "typing_extensions"


### PR DESCRIPTION
Important that it's emitted as `typing_extensions` and not `typing` to be backwards compatible