### PR TITLE
Make synchronizer a context manager for managing event loop life cycle explicitly

### DIFF
--- a/test/_shutdown_ctxmgr.py
+++ b/test/_shutdown_ctxmgr.py
@@ -24,10 +24,13 @@ async def run():
 
 
 s = Synchronizer()
+wrapped_func = s.create_blocking(run)
 
-print("calling wrapped func")
 try:
-    s.create_blocking(run)()
+    with s:
+        print("calling wrapped func")        
+        wrapped_func()
 except KeyboardInterrupt:
     pass
+
 print("eof")

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -2,6 +2,16 @@ import os
 import signal
 import subprocess
 import sys
+from typing import List
+
+def assert_prints(p: subprocess.Popen, *messages: str):
+    for msg in messages:
+        line = p.stdout.readline()
+        if not line:
+            print("STDERR")
+            print(p.stderr.read())
+            raise Exception("Unexpected empty line in output, see stderr:")
+        assert line == msg + "\n"
 
 
 def test_shutdown():
@@ -12,12 +22,58 @@ def test_shutdown():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8"
     )
-    for i in range(3):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == b"running\n"
+    assert_prints(
+        p,
+        "calling wrapped func",
+        "starting up synchronicity event loop",
+        *(["running"] * 3)  # wait for 3 "running" messages before siginting the process
+    )
     p.send_signal(signal.SIGINT)
-    assert p.stdout.readline() == b"cancelled\n"
-    assert p.stdout.readline() == b"stopping\n"
-    assert p.stdout.readline() == b"exiting\n"
-    stderr_content = p.stderr.read()
-    assert b"Traceback" not in stderr_content
+    assert_prints(
+        p,
+        "eof",
+        "start shutting down synchronicity event loop",
+        "cancelled",
+        "stopping",
+        "exiting",
+        "finished shutting down synchronicity event loop",
+    )
+    out, err = p.communicate()
+    assert out == ""
+    assert err == ""
+    assert p.returncode == 0
+
+
+def test_shutdown_ctx_mgr():
+    # We run it in a separate process so we can simulate interrupting it
+    fn = os.path.join(os.path.dirname(__file__), "_shutdown_ctxmgr.py")
+    p = subprocess.Popen(
+        [sys.executable, fn],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8"
+    )
+    assert_prints(
+        p,
+        "starting up synchronicity event loop",  # start up loop explicitly
+        "calling wrapped func",
+        *(["running"] * 3)
+    )
+    p.send_signal(signal.SIGINT)
+    
+    assert_prints(
+        p,
+        "start shutting down synchronicity event loop",
+        "cancelled",
+        "stopping",
+        "exiting",
+        "finished shutting down synchronicity event loop",  # shut down loop explicitly,
+        "eof",
+    )
+    out, err = p.communicate()
+    assert out == ""
+    assert err == ""
+    assert p.returncode == 0


### PR DESCRIPTION
Can also still be used lazily for usages outside of context manager

An advantage of using the context manager is that the event loop can be cleaned up gracefully before the interpreter shuts down, preventing issues with "trying to schedule call after executor shutdown" and other shutdown races/warnings.