### PR TITLE
Raise custom SynchronizerShutdown from ongoing calls when synchronizer shuts down

### DIFF
--- a/synchronicity/exceptions.py
+++ b/synchronicity/exceptions.py
@@ -1,6 +1,10 @@
 import asyncio
 
 
+class SynchronizerShutdown(Exception):
+    pass
+
+
 class UserCodeException(Exception):
     """This is used to wrap and unwrap exceptions in "user code".
 

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -1,13 +1,11 @@
 import asyncio
-from concurrent.futures import thread
 import os
+import pytest
 import signal
 import subprocess
 import sys
 import threading
 import time
-
-import pytest
 
 import synchronicity
 from synchronicity.exceptions import SynchronizerShutdown
@@ -34,17 +32,15 @@ def test_shutdown():
 
 def test_shutdown_raises_shutdown_error():
     s = synchronicity.Synchronizer()
-    
+
     @s.create_blocking
     async def wrapped():
         await asyncio.sleep(10)
-
 
     def shut_down_soon():
         s._get_loop(start=True)  # ensure loop is running
         time.sleep(0.1)
         s._close_loop()
-        
 
     t = threading.Thread(target=shut_down_soon)
     t.start()
@@ -54,15 +50,15 @@ def test_shutdown_raises_shutdown_error():
 
     t.join()
 
+
 @pytest.mark.asyncio
 async def test_shutdown_raises_shutdown_error_async():
     s = synchronicity.Synchronizer()
-    
-    
+
     @s.create_blocking
     async def wrapped():
         await asyncio.sleep(10)
-        
+
     @s.create_blocking
     async def supercall():
         try:
@@ -77,7 +73,6 @@ async def test_shutdown_raises_shutdown_error_async():
         s._get_loop(start=True)  # ensure loop is running
         time.sleep(0.1)
         s._close_loop()
-        
 
     t = threading.Thread(target=shut_down_soon)
     t.start()

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -1,7 +1,16 @@
+import asyncio
+from concurrent.futures import thread
 import os
 import signal
 import subprocess
 import sys
+import threading
+import time
+
+import pytest
+
+import synchronicity
+from synchronicity.exceptions import SynchronizerShutdown
 
 
 def test_shutdown():
@@ -21,3 +30,60 @@ def test_shutdown():
     assert p.stdout.readline() == b"exiting\n"
     stderr_content = p.stderr.read()
     assert b"Traceback" not in stderr_content
+
+
+def test_shutdown_raises_shutdown_error():
+    s = synchronicity.Synchronizer()
+    
+    @s.create_blocking
+    async def wrapped():
+        await asyncio.sleep(10)
+
+
+    def shut_down_soon():
+        s._get_loop(start=True)  # ensure loop is running
+        time.sleep(0.1)
+        s._close_loop()
+        
+
+    t = threading.Thread(target=shut_down_soon)
+    t.start()
+
+    with pytest.raises(SynchronizerShutdown):
+        wrapped()
+
+    t.join()
+
+@pytest.mark.asyncio
+async def test_shutdown_raises_shutdown_error_async():
+    s = synchronicity.Synchronizer()
+    
+    
+    @s.create_blocking
+    async def wrapped():
+        await asyncio.sleep(10)
+        
+    @s.create_blocking
+    async def supercall():
+        try:
+            # loop-internal calls should propagate the CancelledError
+            return await wrapped.aio()
+        except asyncio.CancelledError:
+            raise  # expected
+        except BaseException:
+            raise Exception("asyncio.CancelledError is expected internally")
+
+    def shut_down_soon():
+        s._get_loop(start=True)  # ensure loop is running
+        time.sleep(0.1)
+        s._close_loop()
+        
+
+    t = threading.Thread(target=shut_down_soon)
+    t.start()
+
+    with pytest.raises(SynchronizerShutdown):
+        # calls from outside of the synchronizer loop should get the SynchronizerShutdown
+        await supercall.aio()
+
+    t.join()


### PR DESCRIPTION
Allows us to more easily disambiguate user errors that result in `asyncio.CancelledError` or `concurrent.futures.CancelledError` from those that are emitted by synchronicity itself when it shuts down.

While this does the job, it might make sense to listen to some event `event_loop_shutdown_imminent` in our wrapper calls instead (or additionally) and trigger that signal first, to allow further async calls on the event loop for cleanup before the loop *actually* shuts down. Filing that for a future improvement :)