### PR TITLE
Make class wrapping properly propagate generic base classes

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -605,7 +605,7 @@ class Synchronizer:
                     new_bases.append(wrapped_generic.__class_getitem__(*base.__args__))
                 else:
                     new_bases.append(self._wrap(base, interface, require_already_wrapped=(name is not None)))
-            
+
         bases = tuple(new_bases)
         new_dict = {self._original_attr: cls}
         if cls is not None:

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -17,7 +17,7 @@ import sys
 import typing
 from logging import getLogger
 from pathlib import Path
-from typing import TypeVar
+from typing import TypeVar, overload
 from unittest import mock
 
 import sigtools.specifiers  # type: ignore
@@ -780,18 +780,18 @@ class StubEmitter:
         for overload_func in overloaded_signatures:
             self.imports.add("typing")
             parts.append(f"{signature_indent}@typing.overload")
+            
             if interface:
                 overload_func = synchronizer._wrap(overload_func, interface, name=name)
-
-            parts.append(
-                self._get_function_source(
-                    overload_func,
-                    name,
-                    signature_indent,
-                    body_indent,
-                    transform_signature=transform_signature,
-                )
+            
+            overload_src = self._get_function_source(
+                overload_func,
+                name,
+                signature_indent,
+                body_indent,
+                transform_signature=transform_signature,
             )
+            parts.append(overload_src)
 
         if not overloaded_signatures:
             # only add the functions complete signatures if there are no stubs

--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -17,7 +17,7 @@ import sys
 import typing
 from logging import getLogger
 from pathlib import Path
-from typing import TypeVar, overload
+from typing import TypeVar
 from unittest import mock
 
 import sigtools.specifiers  # type: ignore
@@ -780,10 +780,10 @@ class StubEmitter:
         for overload_func in overloaded_signatures:
             self.imports.add("typing")
             parts.append(f"{signature_indent}@typing.overload")
-            
+
             if interface:
                 overload_func = synchronizer._wrap(overload_func, interface, name=name)
-            
+
             overload_src = self._get_function_source(
                 overload_func,
                 name,

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -275,8 +275,9 @@ class MyClass(Base):
 
 
 def test_class_sync(synchronizer):
-    BlockingMyClass = synchronizer.create_blocking(MyClass)
-    BlockingBase = synchronizer.create_blocking(Base)
+    BlockingBase = synchronizer.create_blocking(Base, name="BlockingBase")
+    BlockingMyClass = synchronizer.create_blocking(MyClass, name="BlockingMyClass")
+    
     assert BlockingMyClass.__name__ == "BlockingMyClass"
     obj = BlockingMyClass(x=42)
     assert isinstance(obj, BlockingMyClass)

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -277,7 +277,7 @@ class MyClass(Base):
 def test_class_sync(synchronizer):
     BlockingBase = synchronizer.create_blocking(Base, name="BlockingBase")
     BlockingMyClass = synchronizer.create_blocking(MyClass, name="BlockingMyClass")
-    
+
     assert BlockingMyClass.__name__ == "BlockingMyClass"
     obj = BlockingMyClass(x=42)
     assert isinstance(obj, BlockingMyClass)

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -398,7 +398,6 @@ def test_synchronicity_generic_subclass():
     assert BlockingSpecific.__bases__ == (BlockingMyGeneric,)
     assert BlockingSpecific.__orig_bases__ == (BlockingMyGeneric[str],)
 
-    
     src = _class_source(BlockingSpecific)
     assert "class BlockingSpecific(BlockingMyGeneric[str]):" in src
 

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -395,6 +395,10 @@ def test_synchronicity_generic_subclass():
     assert Specific.__orig_bases__ == (MyGeneric[str],)
 
     BlockingSpecific = synchronizer.create_blocking(Specific, "BlockingSpecific", __name__)
+    assert BlockingSpecific.__bases__ == (BlockingMyGeneric,)
+    assert BlockingSpecific.__orig_bases__ == (BlockingMyGeneric[str],)
+
+    
     src = _class_source(BlockingSpecific)
     assert "class BlockingSpecific(BlockingMyGeneric[str]):" in src
 


### PR DESCRIPTION
Previously, generic bases classes (with type arguments) weren't properly initialized as such so things like `MyWrappedGeneric[T]` would get a repr that was inherited from its base class instead: '_MyUnwrappedGeneric[T]' which broke type stub signatures.

Now classes that inherit from `typing.Generic[T]` would do so in their wrapped instances as well, and those inheriting from custom generic base classes with specified subtypes like `MyGeneric[str]` have their subclass inherit from the the wrapped equivalent with the same args, e.g `WrappedMyGeneric[str]`.