### PR TITLE
Add license classifier for Apache 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,11 @@ name = "synchronicity"
 version = "0.7.5"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
+classifiers = [
+  "Operating System :: OS Independent",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+]
 
 dependencies = ["sigtools==4.0.1", "typing_extensions>=4.6"]
 requires-python = ">=3.8"


### PR DESCRIPTION
See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for this metadata field

ref: https://modal-com.slack.com/archives/C069MLUT4SJ/p1725566686293809