### PR TITLE
Adds support for lazily restarting synchronizer loop if pid changes (typically on fork)

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 gevent==23.9.1
-mypy==1.8.0
+mypy==1.11.2
 mypy-extensions==1.0.0
 pytest==7.4.4
 pytest-asyncio==0.23.3

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 gevent==23.9.1
-mypy==1.11.2
+mypy==1.8.0
 mypy-extensions==1.0.0
 pytest==7.4.4
 pytest-asyncio==0.23.3

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -4,6 +4,7 @@ import collections.abc
 import contextlib
 import functools
 import inspect
+import os
 import platform
 import threading
 import types
@@ -111,6 +112,7 @@ class Synchronizer:
         self._loop = None
         self._loop_creation_lock = threading.Lock()
         self._thread = None
+        self._owner_pid = None
         self._stopping = None
 
         if platform.system() == "Windows":
@@ -170,6 +172,7 @@ class Synchronizer:
                     if "can't create new thread at interpreter shutdown" not in str(exc):
                         raise exc
 
+            self._owner_pid = os.getpid()
             self._thread = threading.Thread(target=thread_inner, daemon=True)
             self._thread.start()
             is_ready.wait()  # TODO: this might block for a very short time
@@ -182,11 +185,21 @@ class Synchronizer:
                 self._loop.call_soon_threadsafe(self._stopping.set)
             self._thread.join()
             self._thread = None
+            self._loop = None
+            self._owner_pid = None
 
     def __del__(self):
         self._close_loop()
 
-    def _get_loop(self, start=False):
+    def _get_loop(self, start=False) -> asyncio.AbstractEventLoop:
+        if self._thread and not self._thread.is_alive():
+            if self._owner_pid == os.getpid():
+                # warn - thread died without us forking
+                raise RuntimeError("Synchronizer thread unexpectedly died")
+
+            self._thread = None
+            self._loop = None
+
         if self._loop is None and start:
             return self._start_loop()
         return self._loop

--- a/test/_forker.py
+++ b/test/_forker.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import synchronicity
+
+
+synchronizer = synchronicity.Synchronizer()
+
+@synchronizer.create_blocking
+async def dummy():
+    print("done", flush=True)
+
+
+if __name__ == "__main__":
+    dummy()  # this starts a synchronizer loop/thread
+    if not os.fork():
+        assert not synchronizer._thread.is_alive()  # threads don't come along in forks
+        dummy()  # this should still work

--- a/test/_forker.py
+++ b/test/_forker.py
@@ -1,9 +1,9 @@
 import os
-import sys
+
 import synchronicity
 
-
 synchronizer = synchronicity.Synchronizer()
+
 
 @synchronizer.create_blocking
 async def dummy():

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -1,15 +1,15 @@
-import os
-from pathlib import Path
 import subprocess
 import sys
-
-import pytest
-
-import synchronicity
+from pathlib import Path
 
 
 def test_fork_restarts_loop():
-    p = subprocess.Popen([sys.executable, Path(__file__).parent / "_forker.py"], encoding="utf8", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+        [sys.executable, Path(__file__).parent / "_forker.py"],
+        encoding="utf8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     try:
         stdout, stderr = p.communicate(timeout=2)
     except subprocess.TimeoutExpired:

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+import synchronicity
+
+
+def test_fork_restarts_loop():
+    p = subprocess.Popen([sys.executable, Path(__file__).parent / "_forker.py"], encoding="utf8", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        stdout, stderr = p.communicate(timeout=2)
+    except subprocess.TimeoutExpired:
+        p.kill()
+        assert False, "Fork process hanged"
+
+    assert p.returncode == 0
+    assert stdout == "done\ndone\n"


### PR DESCRIPTION
TODO: investigate what happens when the event loop/task references are garbage collected in the new process