### PR TITLE
Preserve user exception __cause__ when propagating exceptions

### DIFF
--- a/synchronicity/async_wrap.py
+++ b/synchronicity/async_wrap.py
@@ -31,7 +31,8 @@ def wraps_by_interface(interface: Interface, func):
                 try:
                     return await user_wrapper(*args, **kwargs)
                 except UserCodeException as uc_exc:
-                    raise uc_exc.exc from None
+                    uc_exc.exc.__suppress_context__ = True
+                    raise uc_exc.exc
 
             return wrapper
 

--- a/synchronicity/combined_types.py
+++ b/synchronicity/combined_types.py
@@ -25,7 +25,11 @@ class FunctionWithAio:
         try:
             return self._func(*args, **kwargs)
         except UserCodeException as uc_exc:
-            raise uc_exc.exc from None
+            # The exception context is from Synchronicity, which may confuse users. Set __suppress_context__ to
+            # True to avoid showing the user those error messages. This will preserve uc_exc.exc.__cause__, but
+            # will cause uc_exc.exc.__context__ to be lost. Unfortunately, I don't know how to avoid that.
+            uc_exc.exc.__suppress_context__ = True
+            raise uc_exc.exc
 
 
 class MethodWithAio:

--- a/synchronicity/combined_types.py
+++ b/synchronicity/combined_types.py
@@ -25,9 +25,6 @@ class FunctionWithAio:
         try:
             return self._func(*args, **kwargs)
         except UserCodeException as uc_exc:
-            # The exception context is from Synchronicity, which may confuse users. Set __suppress_context__ to
-            # True to avoid showing the user those error messages. This will preserve uc_exc.exc.__cause__, but
-            # will cause uc_exc.exc.__context__ to be lost. Unfortunately, I don't know how to avoid that.
             uc_exc.exc.__suppress_context__ = True
             raise uc_exc.exc
 

--- a/synchronicity/exceptions.py
+++ b/synchronicity/exceptions.py
@@ -37,4 +37,5 @@ async def unwrap_coro_exception(coro):
     try:
         return await coro
     except UserCodeException as uc_exc:
-        raise uc_exc.exc from None
+        uc_exc.exc.__suppress_context__ = True
+        raise uc_exc.exc

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -388,7 +388,8 @@ class Synchronizer:
                 else:
                     value = self._run_function_sync(gen.asend(value), interface, original_func)
             except UserCodeException as uc_exc:
-                raise uc_exc.exc from None
+                uc_exc.exc.__suppress_context__ = True
+                raise uc_exc.exc
             except StopAsyncIteration:
                 break
             try:
@@ -407,7 +408,8 @@ class Synchronizer:
                 else:
                     value = await self._run_function_async(gen.asend(value), interface, original_func)
             except UserCodeException as uc_exc:
-                raise uc_exc.exc from None
+                uc_exc.exc.__suppress_context__ = True
+                raise uc_exc.exc
             except StopAsyncIteration:
                 break
             try:
@@ -500,7 +502,8 @@ class Synchronizer:
                     except UserCodeException as uc_exc:
                         # Used to skip a frame when called from `proxy_method`.
                         if unwrap_user_excs and not (Interface.BLOCKING and include_aio_interface):
-                            raise uc_exc.exc from None
+                            uc_exc.exc.__suppress_context__ = True
+                            raise uc_exc.exc
                         else:
                             raise uc_exc
             elif is_asyncgen:
@@ -575,7 +578,8 @@ class Synchronizer:
             try:
                 return wrapped_method(instance, *args, **kwargs)
             except UserCodeException as uc_exc:
-                raise uc_exc.exc from None
+                uc_exc.exc.__suppress_context__ = True
+                raise uc_exc.exc
 
         if interface == Interface.BLOCKING and include_aio_interface and should_have_aio_interface(method):
             async_proxy_method = synchronizer_self._wrap_proxy_method(


### PR DESCRIPTION
This PR fixes an issue where the `__cause__` of user exceptions would not be propagated successfully.

One example of when this issue might come up is if there is a deserialization error in Modal.

Before:

```
Stopping app - uncaught exception raised locally: DeserializationError('Encountered an error when deserializing an object in the local environment (see above for details).').

╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
...
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
DeserializationError: Encountered an error when deserializing an object in the local environment (see above for details).
```

After:

```
Stopping app - uncaught exception raised locally: DeserializationError('Encountered an error when deserializing an object in the local environment (see above for details).').
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
...
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with 
map_location=torch.device('cpu') to map your storages to the CPU.

The above exception was the direct cause of the following exception:

╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
...
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
DeserializationError: Encountered an error when deserializing an object in the local environment (see above for details).
```

Modal script:

```py
import modal

cuda_version = "12.4.0"  # should be no greater than host CUDA version
flavor = "devel"  #  includes full CUDA toolkit
operating_sys = "ubuntu22.04"
tag = f"{cuda_version}-{flavor}-{operating_sys}"

torch_image = (
    modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.11")
    .apt_install("git")
    .pip_install(  # required to build flash-attn
        "ninja",
        "packaging",
        "wheel",
        "torch==2.4.1",
        "numpy",
    )
)

app = modal.App("test-gpu")

with torch_image.imports():
    import torch

@app.function(gpu="T4", image=torch_image)
def test():
    x = torch.randn((4096, 4096)).to("cuda")
    ff1 = torch.nn.Linear(4096, 4096).to("cuda")
    return ff1(x)

@app.local_entrypoint()
def main():
    print(test.remote())
```

Additional testing notes: Exceptions without a `__cause__` should not result in Synchronicity error messages being printed.

## Background

We raise the error like so (in `modal-client`, modified for clarity):

```py
    try:
        return Unpickler(client, io.BytesIO(s)).load()
    except Exception as exc:
        raise DeserializationError(
            f"Encountered an error when deserializing an object in the {env} environment{more}."
        ) from exc
```

Based on [PEP 3134](https://peps.python.org/pep-3134/) the `from exc` sets the DeserializationError's `__cause__` property to `exc`, which is what we want: Python will print both the original Exception and the DeserializationError.

## Problem

However, the DeserializationError is eventually intercepted by Synchronicity, which [reraises the error](https://github.com/modal-labs/synchronicity/blob/d3d38e2cc59196ed603a67684620df3bf4a4b2d3/synchronicity/combined_types.py#L28) like so (abbreviated for clarity):

```py
class FunctionWithAio:
    def __call__(self, *args, **kwargs):
        try:
            return self._func(*args, **kwargs)
        except UserCodeException as uc_exc:
            raise uc_exc.exc from None  # __cause__ is lost here!
```

The `from None` keyword causes `__cause__` to be set to `None`, which causes our original Exception information to be lost.

I believe the commit where this was added was in 509c111e6c659480f6ec14424a6b128c31cbb6d0, titled "Fix something with exception contexts." My guess is the goal of this is to avoid showing the user the exception context ([PEP 409](https://peps.python.org/pep-0409/)), which is from Synchronicity. We cannot just have `raise uc_exc.exc`: this will work great for exceptions with an explicit `__cause__`, but will cause confusing Synchronicity context error messages to be shown to users for exceptions that do not have an explicit `__cause__`.

## Solution

Instead, this PR suppresses the context with

```py
        except UserCodeException as uc_exc:
            # The exception context is from Synchronicity, which may confuse users. Set __suppress_context__ to
            # True to avoid showing the user those error messages. This will preserve uc_exc.exc.__cause__, but
            # will cause uc_exc.exc.__context__ to be lost. Unfortunately, I don't know how to avoid that.
            uc_exc.exc.__suppress_context__ = True
            raise uc_exc.exc
```

See PEP 3134 and PEP 409 for more information. My understanding is Python won't print error messages from `__context__` if `__suppress_context__` is True.

### Alternative approaches

I think we also could have done `raise uc_exc.exc from uc_exc.exc.__cause__` to achieve the same effect: setting `__cause__` implicitly sets `__suppress_context__` to True.

I chose to do `__suppress_context__` since I think that more clearly describes what we're trying to do here, but PEP 409 says the recommended way to suppress context is to do `raise ... from None` so I don't have strong opinions for which implementation approach is better.

## Remaining Issues

Both approaches will still cause the context of the user exception to be lost.

For example, if in our Modal code we did:

```py
    try:
        return Unpickler(client, io.BytesIO(s)).load()
    except Exception as exc:
        raise DeserializationError(
            f"Encountered an error when deserializing an object in the {env} environment{more}."
        )  # note the missing from exc here!
```

without the `from exc`, the original exception would still be preserved in `DeserializationError.__context__`. However, when Synchronicity re-raises the exception, it will cause the context to be lost.

Unfortunately I don't know how to avoid this:
- I don't think setting `uc_exc.exc.__context__` explicitly helps since it will automatically be overwritten when the exception is raised.
- We could do
  ```py
  raise uc_exc.exc from (uc_exc.exc.__cause__ if uc_exc.exc.__cause__ is not None else uc_exc.exc.__context__)
  ```
  but this would change the error message subtly (the wording for exceptions with causes vs. exceptions with context is slightly different).
- We could just raise `UserCodeException` and extract the actual exception in `modal-client`, but this seems like a lot of work.

Regardless, the context of higher-up exceptions will be preserved, so my guess is this is probably OK as long as we remember to `raise ... from` in our Modal code.