### PR TITLE
Remove Interface.ASYNC, Interface.AUTODETECT and synchronizer.create_async

### DIFF
--- a/synchronicity/async_wrap.py
+++ b/synchronicity/async_wrap.py
@@ -20,11 +20,7 @@ def wraps_by_interface(interface: Interface, func):
 
     Note: Does not forward async generator information other than explicit annotations
     """
-    if inspect.iscoroutinefunction(func) and interface in (
-        Interface.ASYNC,
-        Interface._ASYNC_WITH_BLOCKING_TYPES,
-    ):
-
+    if inspect.iscoroutinefunction(func) and interface == Interface._ASYNC_WITH_BLOCKING_TYPES:
         def asyncfunc_deco(user_wrapper):
             @functools.wraps(func)
             async def wrapper(*args, **kwargs):

--- a/synchronicity/interface.py
+++ b/synchronicity/interface.py
@@ -3,8 +3,4 @@ import enum
 
 class Interface(enum.Enum):
     BLOCKING = enum.auto()
-    ASYNC = enum.auto()
-    # temporary internal type until we deprecate the old ASYNC type,
-    # used for `function.aio` async callables accepting/returning BLOCKING types
     _ASYNC_WITH_BLOCKING_TYPES = enum.auto()
-    AUTODETECT = enum.auto()  # DEPRECATED

--- a/test/async_wrap_test.py
+++ b/test/async_wrap_test.py
@@ -10,7 +10,7 @@ def test_wrap_corofunc_using_async():
     async def foo():
         pass
 
-    @wraps_by_interface(Interface.ASYNC, foo)
+    @wraps_by_interface(Interface._ASYNC_WITH_BLOCKING_TYPES, foo)
     async def bar():
         pass
 
@@ -21,7 +21,7 @@ def test_wrap_corofunc_using_non_async():
     async def foo():
         pass
 
-    @wraps_by_interface(Interface.ASYNC, foo)
+    @wraps_by_interface(Interface._ASYNC_WITH_BLOCKING_TYPES, foo)
     def bar():
         pass
 
@@ -46,12 +46,8 @@ def test_wrap_staticmethod(synchronizer):
             return wrapped()
 
     BlockingFoo = synchronizer.create_blocking(Foo)
-    AsyncFoo = synchronizer.create_async(Foo)
 
     assert isinstance(BlockingFoo.__dict__["a_static_method"], FunctionWithAio)
     assert not inspect.iscoroutinefunction(BlockingFoo.__dict__["a_static_method"]._func)
     assert inspect.iscoroutinefunction(BlockingFoo.__dict__["a_static_method"].aio)
 
-    # deprecated interface
-    assert isinstance(AsyncFoo.__dict__["a_static_method"], staticmethod)
-    assert inspect.iscoroutinefunction(AsyncFoo.__dict__["a_static_method"].__func__)

--- a/test/callback_test.py
+++ b/test/callback_test.py
@@ -27,7 +27,7 @@ async def test_blocking(synchronizer):
 
 @pytest.mark.asyncio
 async def test_async(synchronizer):
-    sleep_cb = synchronizer.create_callback(sleep_async, Interface.ASYNC)
+    sleep_cb = synchronizer.create_callback(sleep_async, Interface._ASYNC_WITH_BLOCKING_TYPES)
     t0 = time.time()
     coros = [sleep_cb(200), sleep_cb(300), sleep_cb(300), sleep_cb(300)]
     rets = await asyncio.gather(*coros)

--- a/test/docstring_test.py
+++ b/test/docstring_test.py
@@ -4,7 +4,7 @@ def test_docs(synchronizer):
             """init docs"""
             self._attrs = {}
 
-        def bar(self):
+        async def bar(self):
             """bar docs"""
 
     foo = Foo()
@@ -16,7 +16,4 @@ def test_docs(synchronizer):
     assert blocking_foo.__init__.__doc__ == "init docs"
     assert blocking_foo.bar.__doc__ == "bar docs"
 
-    AsyncFoo = synchronizer.create_async(Foo)
-    async_foo = AsyncFoo()
-    assert async_foo.__init__.__doc__ == "init docs"
-    assert async_foo.bar.__doc__ == "bar docs"
+    assert blocking_foo.bar.aio.__doc__ == "bar docs"

--- a/test/exception_test.py
+++ b/test/exception_test.py
@@ -25,6 +25,7 @@ See https://github.com/modal-labs/synchronicity/pull/165 for more details.
 import asyncio
 import concurrent
 import inspect
+import typing
 import pytest
 import time
 
@@ -92,8 +93,8 @@ def test_function_raises_with_cause_sync_futures(synchronizer):
 @pytest.mark.asyncio
 async def test_function_raises_async(synchronizer):
     t0 = time.time()
-    f_raises_s = synchronizer.create_async(f_raises)
-    coro = f_raises_s()
+    f_raises_s = synchronizer.create_blocking(f_raises)
+    coro = f_raises_s.aio()
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
@@ -105,8 +106,8 @@ async def test_function_raises_async(synchronizer):
 @pytest.mark.asyncio
 async def test_function_raises_with_cause_async(synchronizer):
     t0 = time.time()
-    f_raises_s = synchronizer.create_async(f_raises_with_cause)
-    coro = f_raises_s()
+    f_raises_s = synchronizer.create_blocking(f_raises_with_cause)
+    coro = f_raises_s.aio()
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
@@ -129,15 +130,15 @@ def test_function_raises_baseexc_sync(synchronizer):
     assert exc.value.__suppress_context__ or exc.value.__context__ is None
 
 
-def f_raises_syncwrap():
+def f_raises_syncwrap() -> typing.Coroutine[typing.Any, typing.Any, None]:
     return f_raises()  # returns a coro
 
 
 @pytest.mark.asyncio
 async def test_function_raises_async_syncwrap(synchronizer):
     t0 = time.time()
-    f_raises_syncwrap_s = synchronizer.create_async(f_raises_syncwrap)
-    coro = f_raises_syncwrap_s()
+    f_raises_syncwrap_s = synchronizer.create_blocking(f_raises_syncwrap)
+    coro = f_raises_syncwrap_s.aio()
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
@@ -146,15 +147,15 @@ async def test_function_raises_async_syncwrap(synchronizer):
     assert exc.value.__suppress_context__ or exc.value.__context__ is None
 
 
-def f_raises_with_cause_syncwrap():
+def f_raises_with_cause_syncwrap() -> typing.Coroutine[typing.Any, typing.Any, None]:
     return f_raises_with_cause()  # returns a coro
 
 
 @pytest.mark.asyncio
 async def test_function_raises_with_cause_async_syncwrap(synchronizer):
     t0 = time.time()
-    f_raises_syncwrap_s = synchronizer.create_async(f_raises_with_cause_syncwrap)
-    coro = f_raises_syncwrap_s()
+    f_raises_syncwrap_s = synchronizer.create_blocking(f_raises_with_cause_syncwrap)
+    coro = f_raises_syncwrap_s.aio()
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:

--- a/test/generators_test.py
+++ b/test/generators_test.py
@@ -13,8 +13,8 @@ async def async_producer():
 @pytest.mark.asyncio
 async def test_generator_order_async(synchronizer):
     events.clear()
-    async_producer_synchronized = synchronizer.create_async(async_producer)
-    async for i in async_producer_synchronized():
+    async_producer_synchronized = synchronizer.create_blocking(async_producer)
+    async for i in async_producer_synchronized.aio():
         events.append("consumer")
     assert events == ["producer", "consumer"] * 10
 
@@ -22,8 +22,8 @@ async def test_generator_order_async(synchronizer):
 @pytest.mark.asyncio
 async def test_generator_order_explicit_async(synchronizer):
     events.clear()
-    async_producer_synchronized = synchronizer.create_async(async_producer)
-    async for i in async_producer_synchronized():
+    async_producer_synchronized = synchronizer.create_blocking(async_producer)
+    async for i in async_producer_synchronized.aio():
         events.append("consumer")
     assert events == ["producer", "consumer"] * 10
 
@@ -43,8 +43,8 @@ async def async_bidirectional_producer(i):
 
 @pytest.mark.asyncio
 async def test_bidirectional_generator_async(synchronizer):
-    f = synchronizer.create_async(async_bidirectional_producer)
-    gen = f(42)
+    f = synchronizer.create_blocking(async_bidirectional_producer)
+    gen = f.aio(42)
     value = await gen.asend(None)
     assert value == 42
     with pytest.raises(StopAsyncIteration):
@@ -73,7 +73,7 @@ async def athrow_example_gen():
 
 @pytest.mark.asyncio
 async def test_athrow_async(synchronizer):
-    gen = synchronizer.create_async(athrow_example_gen)()
+    gen = synchronizer.create_blocking(athrow_example_gen).aio()
     v = await gen.asend(None)
     assert v == "hello"
     v = await gen.athrow(ZeroDivisionError)
@@ -90,7 +90,7 @@ def test_athrow_sync(synchronizer):
 
 @pytest.mark.asyncio
 async def test_athrow_baseexc_async(synchronizer):
-    gen = synchronizer.create_async(athrow_example_gen)()
+    gen = synchronizer.create_blocking(athrow_example_gen).aio()
     v = await gen.asend(None)
     assert v == "hello"
     v = await gen.athrow(KeyboardInterrupt)

--- a/test/getattr_test.py
+++ b/test/getattr_test.py
@@ -39,17 +39,15 @@ def test_getattr(synchronizer):
     BlockingFoo = synchronizer.create_blocking(Foo)
 
     blocking_foo = BlockingFoo()
-    blocking_foo.x = 42
-    assert blocking_foo.x == 42
+    blocking_foo.x = 43
+    assert blocking_foo.x == 43
     with pytest.raises(KeyError):
         blocking_foo.y
-    assert blocking_foo.z == 42
+    assert blocking_foo.z == 43
 
     blocking_foo = BlockingFoo.make_foo()
+    blocking_foo.x = 44
     assert isinstance(blocking_foo, BlockingFoo)
 
-    AsyncFoo = synchronizer.create_async(Foo)
-    async_foo = AsyncFoo()
-    async_foo.x = 42
-    assert asyncio.run(async_foo.x) == 42
-    assert async_foo.z == 42
+    # TODO: there is no longer a way to make async properties, but there is this w/ async __getattr__:
+    assert asyncio.run(blocking_foo.__getattr__.aio("x")) == 44

--- a/test/inspect_test.py
+++ b/test/inspect_test.py
@@ -14,9 +14,8 @@ class _Api:
 def test_inspect_coroutinefunction():
     s = Synchronizer()
     BlockingApi = s.create_blocking(_Api)
-    AioApi = s.create_async(_Api)
 
     assert inspect.iscoroutinefunction(BlockingApi.blocking_func) is False
     assert inspect.iscoroutinefunction(BlockingApi.async_func) is False
-    assert inspect.iscoroutinefunction(AioApi.blocking_func) is False
-    assert inspect.iscoroutinefunction(AioApi.async_func) is True
+    assert hasattr(BlockingApi.blocking_func, "aio") is False
+    assert inspect.iscoroutinefunction(BlockingApi.async_func.aio) is True

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -43,30 +43,6 @@ def test_function_sync_future(synchronizer):
     assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
 
 
-@pytest.mark.asyncio
-async def test_function_async_deprecated(synchronizer):
-    t0 = time.time()
-    f_s = synchronizer.create_async(f)
-    assert f_s.__name__ == "async_f"
-    coro = f_s(42)
-    assert inspect.iscoroutine(coro)
-    assert time.time() - t0 < SLEEP_DELAY
-    assert await coro == 1764
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
-
-    # Make sure the same-loop calls work
-    f2_s = synchronizer.create_async(f2)
-    assert f2_s.__name__ == "async_f2"
-    coro = f2_s(f_s, 42)
-    assert await coro == 1764
-
-    # Make sure cross-loop calls work
-    s2 = synchronizer
-    f2_s2 = s2.create_async(f2)
-    assert f2_s2.__name__ == "async_f2"
-    coro = f2_s2(f_s, 42)
-    assert await coro == 1764
-
 
 @pytest.mark.asyncio
 async def test_function_async_as_function_attribute(synchronizer):
@@ -101,8 +77,8 @@ async def test_function_async_block_event_loop(synchronizer):
         # This blocks the event loop, but not the main event loop
         time.sleep(SLEEP_DELAY)
 
-    spinlock_s = synchronizer.create_async(spinlock)
-    spinlock_coro = spinlock_s()
+    spinlock_s = synchronizer.create_blocking(spinlock)
+    spinlock_coro = spinlock_s.aio()
     sleep_coro = asyncio.sleep(SLEEP_DELAY)
 
     t0 = time.time()
@@ -129,9 +105,9 @@ def test_function_many_parallel_sync_futures(synchronizer):
 
 @pytest.mark.asyncio
 async def test_function_many_parallel_async(synchronizer):
-    g = synchronizer.create_async(f)
+    g = synchronizer.create_blocking(f)
     t0 = time.time()
-    coros = [g(i) for i in range(100)]
+    coros = [g.aio(i) for i in range(100)]
     assert inspect.iscoroutine(coros[0])
     assert time.time() - t0 < SLEEP_DELAY
     assert await asyncio.gather(*coros) == [z**2 for z in range(100)]
@@ -221,10 +197,15 @@ def test_sync_lambda_returning_coroutine_sync_futures(synchronizer):
 
 
 @pytest.mark.asyncio
-async def test_sync_lambda_returning_coroutine_async(synchronizer):
+async def test_sync_inline_func_returning_coroutine_async(synchronizer):
     t0 = time.time()
-    g = synchronizer.create_async(lambda z: f(z + 1))
-    coro = g(42)
+
+    # NOTE: we don't create the async variant unless we know the function returns a coroutine
+    def func(z) -> Coroutine:
+        return f(z + 1)
+
+    g = synchronizer.create_blocking(func)
+    coro = g.aio(42)
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY
     assert await coro == 1849
@@ -323,31 +304,6 @@ def test_class_sync_futures(synchronizer):
     assert time.time() - t0 > 2 * SLEEP_DELAY
 
 
-@pytest.mark.asyncio
-async def test_class_async_deprecated(synchronizer):
-    AsyncMyClass = synchronizer.create_async(MyClass)
-    AsyncBase = synchronizer.create_async(Base)
-    assert AsyncMyClass.__name__ == "AsyncMyClass"
-    obj = AsyncMyClass(x=42)
-    assert isinstance(obj, AsyncMyClass)
-    assert isinstance(obj, AsyncBase)
-    await obj.start()
-    coro = obj.get_result()
-    assert inspect.iscoroutine(coro)
-    assert await coro == 1764
-
-    t0 = time.time()
-    async with obj as z:
-        assert z == 42
-        assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
-
-    assert time.time() - t0 > 2 * SLEEP_DELAY
-
-    lst = []
-    async for z in obj:
-        lst.append(z)
-    assert lst == list(range(42))
-
 
 @pytest.mark.asyncio
 async def test_class_async_as_method_attribute(synchronizer):
@@ -380,31 +336,6 @@ async def test_class_async_as_method_attribute(synchronizer):
     assert await obj.my_class_method.aio() == 44
 
 
-@pytest.mark.asyncio
-async def test_class_async_back_and_forth(synchronizer):
-    AsyncMyClass = synchronizer.create_async(MyClass)
-    AsyncBase = synchronizer.create_async(Base)
-    synchronizer.create_blocking(MyClass)
-    async_obj = AsyncMyClass(x=42)
-    assert isinstance(async_obj, AsyncMyClass)
-    assert isinstance(async_obj, AsyncBase)
-    await async_obj.start()
-
-    def get(o):
-        return o.get_result()  # Blocking
-
-    # Make it into a sync object
-    blocking_obj = synchronizer._translate_out(synchronizer._translate_in(async_obj), Interface.BLOCKING)
-    assert type(blocking_obj).__name__ == "BlockingMyClass"
-
-    # Run it in a sync context
-    loop = asyncio.get_event_loop()
-    fut = loop.run_in_executor(None, get, blocking_obj)
-    ret = await fut
-    assert ret == 1764
-
-    # The problem here is that f is already synchronized by another synchronizer, which shouldn't be allowed
-
 
 @pytest.mark.skip(reason="Skip this until we've made it impossible to re-synchronize objects")
 def test_event_loop(synchronizer):
@@ -429,18 +360,18 @@ def test_event_loop(synchronizer):
         synchronizer._start_loop(new_loop)
 
 
-@pytest.mark.parametrize("interface_type", [Interface.BLOCKING, Interface.ASYNC])
-def test_doc_transfer(interface_type, synchronizer):
+def test_doc_transfer(synchronizer):
     class Foo:
         """Hello"""
 
-        def foo(self):
+        async def foo(self):
             """hello"""
 
-    output_class = synchronizer._wrap(Foo, interface_type)
+    output_class = synchronizer.create_blocking(Foo)
 
     assert output_class.__doc__ == "Hello"
     assert output_class.foo.__doc__ == "hello"
+    assert output_class.foo.aio.__doc__ == "hello"
 
 
 def test_set_function_name(synchronizer):

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -43,9 +43,9 @@ def test_sync_to_async(synchronizer):
 
 @pytest.mark.asyncio
 async def test_async_to_async(synchronizer):
-    f_s = synchronizer.create_async(f)
+    f_s = synchronizer.create_blocking(f)
     with pytest.raises(CustomException) as excinfo:
-        await f_s()
+        await f_s.aio()
     check_traceback(excinfo.value)
 
 
@@ -59,9 +59,9 @@ def test_sync_to_async_gen(synchronizer):
 
 @pytest.mark.asyncio
 async def test_async_to_async_gen(synchronizer):
-    gen_s = synchronizer.create_async(gen)
+    gen_s = synchronizer.create_blocking(gen)
     with pytest.raises(CustomException) as excinfo:
-        async for x in gen_s():
+        async for x in gen_s.aio():
             pass
     check_traceback(excinfo.value)
 
@@ -78,7 +78,7 @@ def test_sync_to_async_ctx_mgr(synchronizer):
 @pytest.mark.skip(reason="This one will be much easier to fix once AUTODETECT is gone")
 @pytest.mark.asyncio
 async def test_async_to_async_ctx_mgr(synchronizer):
-    ctx_mgr = synchronizer.create_async(synchronizer.asynccontextmanager(gen))
+    ctx_mgr = synchronizer.create_blocking(synchronizer.asynccontextmanager(gen))
     with pytest.raises(CustomException) as excinfo:
         async with ctx_mgr():
             pass

--- a/test/type_stub_translation_test.py
+++ b/test/type_stub_translation_test.py
@@ -12,12 +12,10 @@ class ImplType:
 synchronizer = Synchronizer()
 
 BlockingType = synchronizer.create_blocking(ImplType, "BlockingType", __name__)
-AsyncType = synchronizer.create_async(ImplType, "AsyncType", __name__)
 
 
 def test_wrapped_class_keeps_class_annotations():
     assert BlockingType.__annotations__ == ImplType.__annotations__
-    assert AsyncType.__annotations__ == AsyncType.__annotations__
 
 
 @pytest.mark.parametrize(
@@ -35,12 +33,12 @@ def test_wrapped_class_keeps_class_annotations():
         ),
         (
             typing.AsyncContextManager[ImplType],
-            Interface.ASYNC,
-            typing.AsyncContextManager[AsyncType],
+            Interface._ASYNC_WITH_BLOCKING_TYPES,
+            typing.AsyncContextManager[BlockingType],
         ),
         (
             typing.Awaitable[typing.Awaitable[str]],
-            Interface.ASYNC,
+            Interface._ASYNC_WITH_BLOCKING_TYPES,
             typing.Awaitable[typing.Awaitable[str]],
         ),
         (typing.Awaitable[typing.Awaitable[str]], Interface.BLOCKING, str),
@@ -52,7 +50,7 @@ def test_wrapped_class_keeps_class_annotations():
             Interface.BLOCKING,
             typing.Union[BlockingType, None],
         ),
-        (typing.Optional[ImplType], Interface.ASYNC, typing.Union[AsyncType, None]),
+        (typing.Optional[ImplType], Interface._ASYNC_WITH_BLOCKING_TYPES, typing.Union[BlockingType, None]),
     ],
 )
 def test_annotation_mapping(t, interface, expected):


### PR DESCRIPTION
They have been deprecated for a long time now and before making larger changes to synchronicity it would be nice to clean up this old stuff and have tests that only test supported interfaces.

While fixing tests I noticed a couple of differences between our "new" `.aio` style async and the old "dedicated async type" wrappers:
* async properties can no longer be used async afaik, since there is no good way to access them
* iterators and context managers are "dual", so you can do stupid things like this without things breaking:

```py
async with wrapped_async_ctx_mgr:  # you don't have to use .aio here - arguably not bad
    ...

with wrapped_async_ctx_mgr.aio():  # you can use sync interface of the context manager returned by .aio here 🤦 works but stupid!
    ...
```