### PR TITLE
Synchronizes propagation of asyncio.CancelledError from caller to executor

### DIFF
--- a/test/support/_shutdown_async_run.py
+++ b/test/support/_shutdown_async_run.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from synchronicity import Synchronizer
+
+
+async def run():
+    try:
+        while True:
+            print("running")
+            await asyncio.sleep(0.3)
+    except asyncio.CancelledError:
+        print("cancelled")
+        await asyncio.sleep(0.1)
+        print("handled cancellation")
+        raise
+    finally:
+        await asyncio.sleep(0.1)
+        print("exit async")
+
+
+s = Synchronizer()
+blocking_run = s.create_blocking(run)
+
+try:
+    asyncio.run(blocking_run.aio())
+except KeyboardInterrupt:
+    print("keyboard interrupt")

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -486,8 +486,8 @@ def test_generic_baseclass():
 
 @pytest.mark.asyncio
 async def test_async_cancellation(synchronizer):
-
     states = []
+
     async def foo(abort_cancellation: bool, cancel_self: bool = False):
         states.append("ready")
         if cancel_self:
@@ -503,10 +503,13 @@ async def test_async_cancellation(synchronizer):
         return "done"
 
     wrapped_foo = synchronizer.create_blocking(foo)
+
     async def start_task(abort_cancellation: bool, cancel_self: bool = False):
         states.clear()
-        calling_task = asyncio.create_task(wrapped_foo.aio(abort_cancellation=abort_cancellation, cancel_self=cancel_self))
-        while not "ready" in states:
+        calling_task = asyncio.create_task(
+            wrapped_foo.aio(abort_cancellation=abort_cancellation, cancel_self=cancel_self)
+        )
+        while "ready" not in states:
             await asyncio.sleep(0.01)  # do't cancel before the task even starts
         return calling_task
 


### PR DESCRIPTION
Async corollary to #166 

When user code using `.aio()` calls have been cancelled, those cancellations have been propagating into the synchronizer thread via the future-wrapping but they haven't been waiting for the other thread to actually respond to the cancellation. This fixes this similarly to how we handle KeyboardInterrupt for sync calls