### PR TITLE
Fix type stub generation for ParamSpecArgs/Kwargs

### DIFF
--- a/synchronicity/type_stubs.py
+++ b/synchronicity/type_stubs.py
@@ -680,6 +680,12 @@ class StubEmitter:
         assert not isinstance(annotation, typing.ForwardRef)  # Forward refs should already have been evaluated!
         args = safe_get_args(annotation)
 
+        if isinstance(annotation, typing_extensions.ParamSpecArgs):
+            return self._formatannotation(typing_extensions.get_origin(annotation)) + "." + "args"
+
+        if isinstance(annotation, typing_extensions.ParamSpecKwargs):
+            return self._formatannotation(typing_extensions.get_origin(annotation)) + "." + "kwargs"
+
         if origin is None or not args:
             if annotation == typing.Sized:
                 return "typing.Sized"  # fix Python 3.8(+?) where the repr is "typing.Sized[]" for some reason

--- a/test/type_stub_helpers/some_mod.py
+++ b/test/type_stub_helpers/some_mod.py
@@ -1,5 +1,10 @@
+import typing_extensions
+
+
 class Foo:
     pass
 
 
 cool: str
+
+P = typing_extensions.ParamSpec("P")

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -616,3 +616,13 @@ def test_concatenate_origin_module():
     src = s.get_source()
     print(src)
     assert "f: typing.Callable[typing_extensions.Concatenate[typing.Any, P], R]" in src
+
+def test_paramspec_args():
+    from .type_stub_helpers.some_mod import P
+
+    def foo(fn: typing.Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> str:
+        return "Hello World!"
+
+    src = _function_source(foo)
+    assert "import test.type_stub_helpers.some_mod" in src
+    assert "def foo(fn: typing.Callable[test.type_stub_helpers.some_mod.P, None], *args: test.type_stub_helpers.some_mod.P.args, **kwargs: test.type_stub_helpers.some_mod.P.kwargs) -> str:" in src  # noqa: E501


### PR DESCRIPTION
This PR fixes an issue with type stub generations for `P.args` and `P.kwargs` when `P` is a `ParamSpec` imported from a different module. It also adds a regression test.

This issue came up in https://github.com/modal-labs/modal-client/pull/2319.

Given:

```py
from some_module import P

def foo(fn: typing.Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> str:
    return "Hello World!"
```

Before (bad):

```py
import some_module

def foo(fn: typing.Callable[some_module.P, None], *args: P.args, **kwargs: P.kwargs) -> str:
    return "Hello World!"
```

After (good):

```py
import some_module

def foo(fn: typing.Callable[some_module.P, None], *args: some_module.P.args, **kwargs: some_module.P.kwargs) -> str:
    return "Hello World!"
```