### PR TITLE
Remove `interface` in a bunch of places

### DIFF
--- a/synchronicity/callback.py
+++ b/synchronicity/callback.py
@@ -7,9 +7,8 @@ class Callback:
 
     Currently only supports non-generator functions."""
 
-    def __init__(self, synchronizer, f, interface):
+    def __init__(self, synchronizer, f):
         self._synchronizer = synchronizer
-        self._interface = interface
         self._f = f
 
     def _invoke(self, args, kwargs):
@@ -30,8 +29,8 @@ class Callback:
 
     async def __call__(self, *args, **kwargs):
         # This translates the opposite way from the code in the synchronizer
-        args = self._synchronizer._translate_out(args, self._interface)
-        kwargs = self._synchronizer._translate_out(kwargs, self._interface)
+        args = self._synchronizer._translate_out(args)
+        kwargs = self._synchronizer._translate_out(kwargs)
 
         # This function may be blocking, so we need to run it on a thread
         loop = asyncio.get_event_loop()

--- a/synchronicity/interface.py
+++ b/synchronicity/interface.py
@@ -3,4 +3,15 @@ import enum
 
 class Interface(enum.Enum):
     BLOCKING = enum.auto()
-    _ASYNC_WITH_BLOCKING_TYPES = enum.auto()
+    _ASYNC_WITH_BLOCKING_TYPES = enum.auto()  # this is *only* used for functions, since all types are blocking
+
+
+# Default names for classes
+DEFAULT_CLASS_PREFIX = "Blocking"
+
+# Default names for functions
+DEFAULT_FUNCTION_PREFIXES = {
+    Interface.BLOCKING: "blocking_",
+    # this is only used internally - usage will be via `.aio` on the blocking function:
+    Interface._ASYNC_WITH_BLOCKING_TYPES: "aio_",
+}

--- a/test/callback_test.py
+++ b/test/callback_test.py
@@ -2,8 +2,6 @@ import asyncio
 import pytest
 import time
 
-from synchronicity import Interface
-
 
 def sleep(ms):
     time.sleep(ms / 1000)

--- a/test/callback_test.py
+++ b/test/callback_test.py
@@ -17,7 +17,7 @@ async def sleep_async(ms):
 
 @pytest.mark.asyncio
 async def test_blocking(synchronizer):
-    sleep_cb = synchronizer.create_callback(sleep, Interface.BLOCKING)
+    sleep_cb = synchronizer.create_callback(sleep)
     t0 = time.time()
     coros = [sleep_cb(200), sleep_cb(300), sleep_cb(300), sleep_cb(300)]
     rets = await asyncio.gather(*coros)
@@ -27,7 +27,7 @@ async def test_blocking(synchronizer):
 
 @pytest.mark.asyncio
 async def test_async(synchronizer):
-    sleep_cb = synchronizer.create_callback(sleep_async, Interface._ASYNC_WITH_BLOCKING_TYPES)
+    sleep_cb = synchronizer.create_callback(sleep_async)
     t0 = time.time()
     coros = [sleep_cb(200), sleep_cb(300), sleep_cb(300), sleep_cb(300)]
     rets = await asyncio.gather(*coros)
@@ -51,7 +51,7 @@ async def test_translate(synchronizer):
         x = foo.get()
         return BlockingFoo(x + 1)
 
-    f_cb = synchronizer.create_callback(f, Interface.BLOCKING)
+    f_cb = synchronizer.create_callback(f)
 
     foo1 = Foo(42)
     foo2 = await f_cb(foo1)

--- a/test/mark_test.py
+++ b/test/mark_test.py
@@ -1,6 +1,0 @@
-def test_function_sync(synchronizer):
-    async def f(x):
-        return x**2
-
-    f_blocking = synchronizer.create_blocking(f)
-    assert f_blocking(42) == 1764

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -8,7 +8,7 @@ from typing import Coroutine
 from unittest.mock import MagicMock
 
 import synchronicity
-from synchronicity import Interface, Synchronizer
+from synchronicity import Synchronizer
 
 SLEEP_DELAY = 0.1
 

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -433,7 +433,7 @@ def test_no_output_translation(monkeypatch, synchronizer):
     out_translate_spy = MagicMock(wraps=synchronizer._translate_scalar_out)
     monkeypatch.setattr(synchronizer, "_translate_scalar_out", out_translate_spy)
     does_output_translation(3.14)  # test without decorator, this *should* do input translation
-    out_translate_spy.assert_called_once_with("3.14", Interface.BLOCKING)
+    out_translate_spy.assert_called_once_with("3.14")
 
     out_translate_spy.reset_mock()
     without_output_translation(3.14)

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -617,6 +617,7 @@ def test_concatenate_origin_module():
     print(src)
     assert "f: typing.Callable[typing_extensions.Concatenate[typing.Any, P], R]" in src
 
+
 def test_paramspec_args():
     from .type_stub_helpers.some_mod import P
 
@@ -625,4 +626,7 @@ def test_paramspec_args():
 
     src = _function_source(foo)
     assert "import test.type_stub_helpers.some_mod" in src
-    assert "def foo(fn: typing.Callable[test.type_stub_helpers.some_mod.P, None], *args: test.type_stub_helpers.some_mod.P.args, **kwargs: test.type_stub_helpers.some_mod.P.kwargs) -> str:" in src  # noqa: E501
+    assert (
+        "def foo(fn: typing.Callable[test.type_stub_helpers.some_mod.P, None], *args: test.type_stub_helpers.some_mod.P.args, **kwargs: test.type_stub_helpers.some_mod.P.kwargs) -> str:"
+        in src
+    )  # noqa: E501

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -627,6 +627,6 @@ def test_paramspec_args():
     src = _function_source(foo)
     assert "import test.type_stub_helpers.some_mod" in src
     assert (
-        "def foo(fn: typing.Callable[test.type_stub_helpers.some_mod.P, None], *args: test.type_stub_helpers.some_mod.P.args, **kwargs: test.type_stub_helpers.some_mod.P.kwargs) -> str:"
+        "def foo(fn: typing.Callable[test.type_stub_helpers.some_mod.P, None], *args: test.type_stub_helpers.some_mod.P.args, **kwargs: test.type_stub_helpers.some_mod.P.kwargs) -> str:"  # noqa
         in src
     )  # noqa: E501


### PR DESCRIPTION
There is only one public interface now (Interface.BLOCKING) and the only place we use the "Interface._ASYNC_WITH_BLOCKING_TYPES" one is to mark the internal async wrapper definitions (the .aio variant of functions) which we should hopefully be able to get rid of soon too