### PR TITLE
Windows ctrl c support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,25 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # run all variants across python versions/os to completion
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: ["ubuntu-latest"]
+        include:
+          - os: "macos-12" # x86-64
+            python-version: "3.10"
+          - os: "macos-14" # ARM64 (M1)
+            python-version: "3.10"
+          - os: "windows-latest"
+            python-version: "3.10"
+
+    runs-on: ${{ matrix.os }}
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,4 @@ pytest==7.4.4
 pytest-asyncio==0.23.3
 pre-commit==3.5.0
 ruff==0.2.0
+console-ctrl==0.1.0

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -317,7 +317,14 @@ class Synchronizer:
 
         fut = asyncio.run_coroutine_threadsafe(wrapper_coro(), loop)
         try:
-            value = fut.result()
+            while 1:
+                try:
+                    # poll every second to give Windows a chance to abort on Ctrl-C
+                    #
+                    value = fut.result(timeout=0.1)
+                    break
+                except concurrent.futures.TimeoutError:
+                    pass
         except KeyboardInterrupt as exc:
             # in case there is a keyboard interrupt while we are waiting
             # we cancel the *underlying* coro_task (unlike what fut.cancel() would do)
@@ -326,9 +333,10 @@ class Synchronizer:
             loop.call_soon_threadsafe(coro_task.cancel)
             try:
                 value = fut.result()
-            except concurrent.futures.CancelledError:
+            except concurrent.futures.CancelledError as expected_cancellation:
                 # we *expect* this cancellation, but defer to the passed coro to potentially
                 # intercept and treat the cancellation some other way
+                expected_cancellation.__suppress_context__ = True
                 raise exc  # if cancel - re-raise the original KeyboardInterrupt again
 
         if getattr(original_func, self._output_translation_attr, True):

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -2,7 +2,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows can't fork")
 def test_fork_restarts_loop():
     p = subprocess.Popen(
         [sys.executable, Path(__file__).parent / "support" / "_forker.py"],

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 class PopenWithCtrlC(subprocess.Popen):
     def __init__(self, *args, creationflags=0, **kwargs):
         if sys.platform == "win32":

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -31,23 +31,24 @@ def test_shutdown():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown.py"
     p = PopenWithCtrlC(
-        [sys.executable, fn],
+        [sys.executable, "-u", fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8"
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == b"running\n"
+        assert p.stdout.readline() == "running\n"
     p.send_ctrl_c()
-    assert p.stdout.readline() == b"cancelled\n"
-    assert p.stdout.readline() == b"handled cancellation\n"
-    assert p.stdout.readline() == b"exit async\n"
+    assert p.stdout.readline() == "cancelled\n"
+    assert p.stdout.readline() == "handled cancellation\n"
+    assert p.stdout.readline() == "exit async\n"
     assert (
-        p.stdout.readline() == b"keyboard interrupt\n"
+        p.stdout.readline() == "keyboard interrupt\n"
     )  # we want the keyboard interrupt to come *after* the running function has been cancelled!
 
     stderr_content = p.stderr.read()
-    assert b"Traceback" not in stderr_content
+    print("stderr:", stderr_content)
+    assert "Traceback" not in stderr_content
 
 
 def test_keyboard_interrupt_reraised_as_is(synchronizer):
@@ -63,34 +64,34 @@ def test_shutdown_during_ctx_mgr_setup():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
     p = PopenWithCtrlC(
-        [sys.executable, fn, "enter"],
+        [sys.executable, "-u", fn, "enter"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8",
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == b"enter\n"
+        assert p.stdout.readline() == "enter\n"
     p.send_ctrl_c()
-    assert p.stdout.readline() == b"exit\n"
-    assert p.stdout.readline() == b"keyboard interrupt\n"
-    assert p.stderr.read() == b""
+    assert p.stdout.readline() == "exit\n"
+    assert p.stdout.readline() == "keyboard interrupt\n"
+    assert p.stderr.read() == ""
 
 
 def test_shutdown_during_ctx_mgr_yield():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
     p = PopenWithCtrlC(
-        [sys.executable, fn, "yield"],
+        [sys.executable, "-u", fn, "yield"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8"
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == b"in ctx\n"
+        assert p.stdout.readline() == "in ctx\n"
     p.send_ctrl_c()
-    assert p.stdout.readline() == b"exit\n"
-    assert p.stdout.readline() == b"keyboard interrupt\n"
-    assert p.stderr.read() == b""
+    assert p.stdout.readline() == "exit\n"
+    assert p.stdout.readline() == "keyboard interrupt\n"
+    assert p.stderr.read() == ""
 
 
 def test_shutdown_during_async_run():
@@ -99,7 +100,6 @@ def test_shutdown_during_async_run():
         [sys.executable, fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
         encoding="utf-8",
     )
     for i in range(2):  # this number doesn't matter, it's a while loop

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -4,11 +4,32 @@ import subprocess
 import sys
 from pathlib import Path
 
+class PopenWithCtrlC(subprocess.Popen):
+    def __init__(self, *args, creationflags=0, **kwargs):
+        if sys.platform == "win32":
+            # needed on windows to separate ctrl-c lifecycle of subprocess from parent:
+            creationflags = creationflags | subprocess.CREATE_NEW_CONSOLE  # type: ignore
+
+        super().__init__(*args, **kwargs, creationflags=creationflags)
+
+    def send_ctrl_c(self):
+        # platform independent way to replicate the behavior of Ctrl-C:ing a cli app
+        if sys.platform == "win32":
+            # windows doesn't support sigint, and subprocess.CTRL_C_EVENT has a bunch
+            # of gotchas since it's bound to a console which is the same for the parent
+            # process by default, and can't be sent using the python standard library
+            # to a separate process's console
+            import console_ctrl
+
+            console_ctrl.send_ctrl_c(self.pid)  # noqa [E731]
+        else:
+            self.send_signal(signal.SIGINT)
+
 
 def test_shutdown():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -16,7 +37,7 @@ def test_shutdown():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == b"running\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == b"cancelled\n"
     assert p.stdout.readline() == b"handled cancellation\n"
     assert p.stdout.readline() == b"exit async\n"
@@ -40,7 +61,7 @@ def test_keyboard_interrupt_reraised_as_is(synchronizer):
 def test_shutdown_during_ctx_mgr_setup():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn, "enter"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -48,7 +69,7 @@ def test_shutdown_during_ctx_mgr_setup():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == b"enter\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == b"exit\n"
     assert p.stdout.readline() == b"keyboard interrupt\n"
     assert p.stderr.read() == b""
@@ -57,7 +78,7 @@ def test_shutdown_during_ctx_mgr_setup():
 def test_shutdown_during_ctx_mgr_yield():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn, "yield"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -65,7 +86,7 @@ def test_shutdown_during_ctx_mgr_yield():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == b"in ctx\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == b"exit\n"
     assert p.stdout.readline() == b"keyboard interrupt\n"
     assert p.stderr.read() == b""
@@ -73,7 +94,7 @@ def test_shutdown_during_ctx_mgr_yield():
 
 def test_shutdown_during_async_run():
     fn = Path(__file__).parent / "support" / "_shutdown_async_run.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -82,7 +103,7 @@ def test_shutdown_during_async_run():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == "running\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == "cancelled\n"
     assert p.stdout.readline() == "handled cancellation\n"
     assert p.stdout.readline() == "exit async\n"

--- a/test/type_stub_e2e_test.py
+++ b/test/type_stub_e2e_test.py
@@ -84,6 +84,7 @@ def test_mypy_assertions(interface_file):
         ),
     ],
 )
+@pytest.mark.skipif(sys.platform == "win32", reason="temp_assertion_file permissions issues on github actions (windows)")
 def test_failing_assertion(interface_file, failing_assertion, error_matches):
     # since there appears to be no good way of asserting failing type checks (and skipping to the next assertion)
     # we use the assertion file as a template to insert statements that should fail type checking


### PR DESCRIPTION
Turns out any of our blocking wrappers can't be interrupted by Ctrl-C on windows since `concurrent.futures.Future.result()` can't be interrupted by "ctrl-c events" there. Fix is to do the result call with 0.1s timeouts in a loop instead when waiting for results.

This PR also enables CI for windows and mac...

<!--
  ✍️ Write a short summary of this change, then request review from a recent contributor.
-->

