### PR TITLE
Windows ctrl c support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,25 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # run all variants across python versions/os to completion
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: ["ubuntu-latest"]
+        include:
+          - os: "macos-12" # x86-64
+            python-version: "3.10"
+          - os: "macos-14" # ARM64 (M1)
+            python-version: "3.10"
+          - os: "windows-latest"
+            python-version: "3.10"
+
+    runs-on: ${{ matrix.os }}
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Run Python Tests
 on: push
 
 jobs:
-  build:
+  tests:
     strategy:
       fail-fast: false # run all variants across python versions/os to completion
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.2.0"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.7.1"
     hooks:
       - id: ruff
         # Autofix, and respect `exclude` and `extend-exclude` settings.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,5 +4,5 @@ mypy-extensions==1.0.0
 pytest==7.4.4
 pytest-asyncio==0.23.3
 pre-commit==3.5.0
-ruff==0.2.0
+ruff==0.7.1
 console-ctrl==0.1.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,4 @@ pytest==7.4.4
 pytest-asyncio==0.23.3
 pre-commit==3.5.0
 ruff==0.2.0
+console-ctrl==0.1.0

--- a/synchronicity/async_utils.py
+++ b/synchronicity/async_utils.py
@@ -1,0 +1,89 @@
+import asyncio
+import signal
+import sys
+import threading
+import typing
+
+from synchronicity.exceptions import NestedEventLoops
+
+T = typing.TypeVar("T")
+
+class Runner:
+    """Simplified backport of asyncio.Runner from Python 3.11
+
+    Like asyncio.run() but allows multiple calls to the same event loop
+    before teardown, and is converts sigints into graceful cancellations
+    similar to asyncio.run on Python 3.11+.
+    """
+
+    def __enter__(self) -> "Runner":
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass  # no event loop - this is what we expect!
+        else:
+            raise NestedEventLoops()
+
+        self._loop = asyncio.new_event_loop()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._loop.run_until_complete(self._loop.shutdown_asyncgens())
+        if sys.version_info[:2] >= (3, 9):
+            # Introduced in Python 3.9
+            self._loop.run_until_complete(self._loop.shutdown_default_executor())
+
+        self._loop.close()
+        return False
+
+    def run(self, coro: typing.Awaitable[T]) -> T:
+        is_main_thread = threading.current_thread() == threading.main_thread()
+        self._num_sigints = 0
+
+        coro_task = asyncio.ensure_future(coro, loop=self._loop)
+
+        async def wrapper_coro():
+            # this wrapper is needed since run_coroutine_threadsafe *only* accepts coroutines
+            return await coro_task
+
+        def _sigint_handler(signum, frame):
+            # cancel the task in order to have run_until_complete return soon and
+            # prevent a bunch of unwanted tracebacks when shutting down the
+            # event loop.
+
+            # this basically replicates the sigint handler installed by asyncio.run()
+            self._num_sigints += 1
+            if self._num_sigints == 1:
+                # first sigint is graceful
+                self._loop.call_soon_threadsafe(coro_task.cancel)
+                return
+
+            # this should normally not happen, but the second sigint would "hard kill" the event loop
+            # by raising KeyboardInterrupt inside of it
+            raise KeyboardInterrupt()
+
+        original_sigint_handler = None
+        try:
+            # only install signal handler if running from main thread and we haven't disabled sigint
+            handle_sigint = is_main_thread and signal.getsignal(signal.SIGINT) == signal.default_int_handler
+
+            if handle_sigint:
+                # intentionally not using _loop.add_signal_handler since it's slow (?)
+                # and not available on Windows. We just don't want the sigint to
+                # mess with the event loop anyways
+                original_sigint_handler = signal.signal(signal.SIGINT, _sigint_handler)
+        except KeyboardInterrupt:
+            # this is quite unlikely, but with bad timing we could get interrupted before
+            # installing the sigint handler and this has happened repeatedly in unit tests
+            _sigint_handler(signal.SIGINT, None)
+
+        try:
+            return self._loop.run_until_complete(wrapper_coro())
+        except asyncio.CancelledError:
+            if self._num_sigints > 0:
+                raise KeyboardInterrupt()  # might want to use original_sigint_handler here instead?
+            raise  # "internal" cancellations, not triggered by KeyboardInterrupt
+        finally:
+            if original_sigint_handler:
+                # reset signal handler
+                signal.signal(signal.SIGINT, original_sigint_handler)

--- a/synchronicity/async_utils.py
+++ b/synchronicity/async_utils.py
@@ -8,6 +8,7 @@ from synchronicity.exceptions import NestedEventLoops
 
 T = typing.TypeVar("T")
 
+
 class Runner:
     """Simplified backport of asyncio.Runner from Python 3.11
 

--- a/synchronicity/exceptions.py
+++ b/synchronicity/exceptions.py
@@ -39,3 +39,7 @@ async def unwrap_coro_exception(coro):
     except UserCodeException as uc_exc:
         uc_exc.exc.__suppress_context__ = True
         raise uc_exc.exc
+
+
+class NestedEventLoops(Exception):
+    pass

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -383,6 +383,7 @@ class Synchronizer:
                         continue
 
             except asyncio.CancelledError:
+                print("DEBUG:cancel")
                 if a_fut.cancelled():
                     raise  # cancellation came from within c_fut
                 loop.call_soon_threadsafe(coro_task.cancel)  # cancel inner task

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -20,7 +20,6 @@ import typing_extensions
 from synchronicity.annotations import evaluated_annotation
 from synchronicity.combined_types import FunctionWithAio, MethodWithAio
 
-
 from .async_wrap import wraps_by_interface
 from .callback import Callback
 from .exceptions import UserCodeException, unwrap_coro_exception, wrap_coro_exception
@@ -384,7 +383,7 @@ class Synchronizer:
                     except asyncio.TimeoutError:
                         continue
 
-            except asyncio.CancelledError as exc:
+            except asyncio.CancelledError:
                 if a_fut.cancelled():
                     raise  # cancellation came from within c_fut
                 loop.call_soon_threadsafe(coro_task.cancel)  # cancel inner task

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -317,7 +317,14 @@ class Synchronizer:
 
         fut = asyncio.run_coroutine_threadsafe(wrapper_coro(), loop)
         try:
-            value = fut.result()
+            while 1:
+                try:
+                    # poll every second to give Windows a chance to abort on Ctrl-C
+                    #
+                    value = fut.result(timeout=0.1)
+                    break
+                except concurrent.futures.TimeoutError:
+                    pass
         except KeyboardInterrupt as exc:
             # in case there is a keyboard interrupt while we are waiting
             # we cancel the *underlying* coro_task (unlike what fut.cancel() would do)
@@ -326,9 +333,10 @@ class Synchronizer:
             loop.call_soon_threadsafe(coro_task.cancel)
             try:
                 value = fut.result()
-            except concurrent.futures.CancelledError:
+            except concurrent.futures.CancelledError as expected_cancellation:
                 # we *expect* this cancellation, but defer to the passed coro to potentially
                 # intercept and treat the cancellation some other way
+                expected_cancellation.__suppress_context__ = True
                 raise exc  # if cancel - re-raise the original KeyboardInterrupt again
 
         if getattr(original_func, self._output_translation_attr, True):

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -2,7 +2,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows can't fork")
 def test_fork_restarts_loop():
     p = subprocess.Popen(
         [sys.executable, Path(__file__).parent / "support" / "_forker.py"],

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -1,8 +1,7 @@
+import pytest
 import subprocess
 import sys
 from pathlib import Path
-
-import pytest
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows can't fork")

--- a/test/nowrap_test.py
+++ b/test/nowrap_test.py
@@ -23,8 +23,8 @@ def test_nowrap():
 
     t0 = time.time()
     assert my_obj.f(111) == 12321
-    assert 0.19 < time.time() - t0 < 0.21
+    assert 0.15 < time.time() - t0 < 0.25
 
     t0 = time.time()
     assert my_obj.g(111) == 1367631
-    assert 0.19 < time.time() - t0 < 0.21
+    assert 0.15 < time.time() - t0 < 0.25

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -86,8 +86,8 @@ def test_shutdown_during_ctx_mgr_yield():
     assert p.stderr.read() == ""
 
 
-@pytest.mark.parametrize("i", range(10))  # don't allow this to flake!
-def test_shutdown_during_async_run(i):
+@pytest.mark.parametrize("run_number", range(10))  # don't allow this to flake!
+def test_shutdown_during_async_run(run_number):
     fn = Path(__file__).parent / "support" / "_shutdown_async_run.py"
     p = PopenWithCtrlC(
         [sys.executable, "-u", fn],
@@ -102,18 +102,16 @@ def test_shutdown_during_async_run(i):
         print(line_data)
         return line_data
 
-    for i in range(2):  # this number doesn't matter, it's a while loop
-        assert line() == "running\n"
+    assert line() == "running\n"
     p.send_ctrl_c()
+    print("sigint sent")
     while (next_line := line()) == "running\n":
         pass
-    assert next_line == "DEBUG:cancel\n"
-    assert line() == "cancelled\n"
-    assert line() == "handled cancellation\n"
-    assert line() == "exit async\n"
-    assert (
-        line() == "keyboard interrupt\n"
-    )  # we want the keyboard interrupt to come *after* the running function has been cancelled!
-
-    stderr_content = p.stderr.read()
-    assert "Traceback" not in stderr_content
+    assert next_line == "cancelled\n"
+    stdout, stderr = p.communicate(timeout=5)
+    print(stderr)
+    assert stdout == """handled cancellation
+exit async
+keyboard interrupt
+"""
+    assert stderr == ""

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -30,12 +30,7 @@ class PopenWithCtrlC(subprocess.Popen):
 def test_shutdown():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown.py"
-    p = PopenWithCtrlC(
-        [sys.executable, "-u", fn],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        encoding="utf8"
-    )
+    p = PopenWithCtrlC([sys.executable, "-u", fn], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8")
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == "running\n"
     p.send_ctrl_c()
@@ -81,10 +76,7 @@ def test_shutdown_during_ctx_mgr_yield():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
     p = PopenWithCtrlC(
-        [sys.executable, "-u", fn, "yield"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        encoding="utf8"
+        [sys.executable, "-u", fn, "yield"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8"
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == "in ctx\n"

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -94,11 +94,13 @@ def test_shutdown_during_async_run():
         stderr=subprocess.PIPE,
         encoding="utf-8",
     )
+
     def line():
         # debugging help
-        l = p.stdout.readline()
-        print(l)
-        return l
+        line_data = p.stdout.readline()
+        print(line_data)
+        return line_data
+
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert line() == "running\n"
     p.send_ctrl_c()

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 class PopenWithCtrlC(subprocess.Popen):
     def __init__(self, *args, creationflags=0, **kwargs):
         if sys.platform == "win32":

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -107,7 +107,8 @@ def test_shutdown_during_async_run(i):
     p.send_ctrl_c()
     while (next_line := line()) == "running\n":
         pass
-    assert next_line == "cancelled\n"
+    assert next_line == "DEBUG:cancel\n"
+    assert line() == "cancelled\n"
     assert line() == "handled cancellation\n"
     assert line() == "exit async\n"
     assert (

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -31,23 +31,24 @@ def test_shutdown():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown.py"
     p = PopenWithCtrlC(
-        [sys.executable, fn],
+        [sys.executable, "-u", fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8"
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == b"running\n"
+        assert p.stdout.readline() == "running\n"
     p.send_ctrl_c()
-    assert p.stdout.readline() == b"cancelled\n"
-    assert p.stdout.readline() == b"handled cancellation\n"
-    assert p.stdout.readline() == b"exit async\n"
+    assert p.stdout.readline() == "cancelled\n"
+    assert p.stdout.readline() == "handled cancellation\n"
+    assert p.stdout.readline() == "exit async\n"
     assert (
-        p.stdout.readline() == b"keyboard interrupt\n"
+        p.stdout.readline() == "keyboard interrupt\n"
     )  # we want the keyboard interrupt to come *after* the running function has been cancelled!
 
     stderr_content = p.stderr.read()
-    assert b"Traceback" not in stderr_content
+    print("stderr:", stderr_content)
+    assert "Traceback" not in stderr_content
 
 
 def test_keyboard_interrupt_reraised_as_is(synchronizer):
@@ -63,34 +64,34 @@ def test_shutdown_during_ctx_mgr_setup():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
     p = PopenWithCtrlC(
-        [sys.executable, fn, "enter"],
+        [sys.executable, "-u", fn, "enter"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8",
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == b"enter\n"
+        assert p.stdout.readline() == "enter\n"
     p.send_ctrl_c()
-    assert p.stdout.readline() == b"exit\n"
-    assert p.stdout.readline() == b"keyboard interrupt\n"
-    assert p.stderr.read() == b""
+    assert p.stdout.readline() == "exit\n"
+    assert p.stdout.readline() == "keyboard interrupt\n"
+    assert p.stderr.read() == ""
 
 
 def test_shutdown_during_ctx_mgr_yield():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
     p = PopenWithCtrlC(
-        [sys.executable, fn, "yield"],
+        [sys.executable, "-u", fn, "yield"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
+        encoding="utf8"
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == b"in ctx\n"
+        assert p.stdout.readline() == "in ctx\n"
     p.send_ctrl_c()
-    assert p.stdout.readline() == b"exit\n"
-    assert p.stdout.readline() == b"keyboard interrupt\n"
-    assert p.stderr.read() == b""
+    assert p.stdout.readline() == "exit\n"
+    assert p.stdout.readline() == "keyboard interrupt\n"
+    assert p.stderr.read() == ""
 
 
 def test_shutdown_during_async_run():
@@ -99,7 +100,6 @@ def test_shutdown_during_async_run():
         [sys.executable, fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env={"PYTHONUNBUFFERED": "1"},
         encoding="utf-8",
     )
     for i in range(2):  # this number doesn't matter, it's a while loop

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -4,11 +4,32 @@ import subprocess
 import sys
 from pathlib import Path
 
+class PopenWithCtrlC(subprocess.Popen):
+    def __init__(self, *args, creationflags=0, **kwargs):
+        if sys.platform == "win32":
+            # needed on windows to separate ctrl-c lifecycle of subprocess from parent:
+            creationflags = creationflags | subprocess.CREATE_NEW_CONSOLE  # type: ignore
+
+        super().__init__(*args, **kwargs, creationflags=creationflags)
+
+    def send_ctrl_c(self):
+        # platform independent way to replicate the behavior of Ctrl-C:ing a cli app
+        if sys.platform == "win32":
+            # windows doesn't support sigint, and subprocess.CTRL_C_EVENT has a bunch
+            # of gotchas since it's bound to a console which is the same for the parent
+            # process by default, and can't be sent using the python standard library
+            # to a separate process's console
+            import console_ctrl
+
+            console_ctrl.send_ctrl_c(self.pid)  # noqa [E731]
+        else:
+            self.send_signal(signal.SIGINT)
+
 
 def test_shutdown():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -16,7 +37,7 @@ def test_shutdown():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == b"running\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == b"cancelled\n"
     assert p.stdout.readline() == b"handled cancellation\n"
     assert p.stdout.readline() == b"exit async\n"
@@ -40,7 +61,7 @@ def test_keyboard_interrupt_reraised_as_is(synchronizer):
 def test_shutdown_during_ctx_mgr_setup():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn, "enter"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -48,7 +69,7 @@ def test_shutdown_during_ctx_mgr_setup():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == b"enter\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == b"exit\n"
     assert p.stdout.readline() == b"keyboard interrupt\n"
     assert p.stderr.read() == b""
@@ -57,7 +78,7 @@ def test_shutdown_during_ctx_mgr_setup():
 def test_shutdown_during_ctx_mgr_yield():
     # We run it in a separate process so we can simulate interrupting it
     fn = Path(__file__).parent / "support" / "_shutdown_ctx_mgr.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn, "yield"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -65,7 +86,7 @@ def test_shutdown_during_ctx_mgr_yield():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == b"in ctx\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == b"exit\n"
     assert p.stdout.readline() == b"keyboard interrupt\n"
     assert p.stderr.read() == b""
@@ -73,7 +94,7 @@ def test_shutdown_during_ctx_mgr_yield():
 
 def test_shutdown_during_async_run():
     fn = Path(__file__).parent / "support" / "_shutdown_async_run.py"
-    p = subprocess.Popen(
+    p = PopenWithCtrlC(
         [sys.executable, fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -82,7 +103,7 @@ def test_shutdown_during_async_run():
     )
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert p.stdout.readline() == "running\n"
-    p.send_signal(signal.SIGINT)
+    p.send_ctrl_c()
     assert p.stdout.readline() == "cancelled\n"
     assert p.stdout.readline() == "handled cancellation\n"
     assert p.stdout.readline() == "exit async\n"

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -86,7 +86,8 @@ def test_shutdown_during_ctx_mgr_yield():
     assert p.stderr.read() == ""
 
 
-def test_shutdown_during_async_run():
+@pytest.mark.parametrize("i", range(10))  # don't allow this to flake!
+def test_shutdown_during_async_run(i):
     fn = Path(__file__).parent / "support" / "_shutdown_async_run.py"
     p = PopenWithCtrlC(
         [sys.executable, "-u", fn],
@@ -104,7 +105,9 @@ def test_shutdown_during_async_run():
     for i in range(2):  # this number doesn't matter, it's a while loop
         assert line() == "running\n"
     p.send_ctrl_c()
-    assert line() == "cancelled\n"
+    while (next_line := line()) == "running\n":
+        pass
+    assert next_line == "cancelled\n"
     assert line() == "handled cancellation\n"
     assert line() == "exit async\n"
     assert (

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -89,19 +89,24 @@ def test_shutdown_during_ctx_mgr_yield():
 def test_shutdown_during_async_run():
     fn = Path(__file__).parent / "support" / "_shutdown_async_run.py"
     p = PopenWithCtrlC(
-        [sys.executable, fn],
+        [sys.executable, "-u", fn],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
     )
+    def line():
+        # debugging help
+        l = p.stdout.readline()
+        print(l)
+        return l
     for i in range(2):  # this number doesn't matter, it's a while loop
-        assert p.stdout.readline() == "running\n"
+        assert line() == "running\n"
     p.send_ctrl_c()
-    assert p.stdout.readline() == "cancelled\n"
-    assert p.stdout.readline() == "handled cancellation\n"
-    assert p.stdout.readline() == "exit async\n"
+    assert line() == "cancelled\n"
+    assert line() == "handled cancellation\n"
+    assert line() == "exit async\n"
     assert (
-        p.stdout.readline() == "keyboard interrupt\n"
+        line() == "keyboard interrupt\n"
     )  # we want the keyboard interrupt to come *after* the running function has been cancelled!
 
     stderr_content = p.stderr.read()

--- a/test/support/_shutdown_async_run.py
+++ b/test/support/_shutdown_async_run.py
@@ -1,13 +1,22 @@
 import asyncio
+import sys
 
 from synchronicity import Synchronizer
+
+if sys.version_info < (3, 11):
+    # asyncio.Runner doesn't exist prior to 3.11,
+    # and asyncio.run() is unsafe for sigints on <3.11
+    from synchronicity.async_utils import Runner
+else:
+    from asyncio import Runner
 
 
 async def run():
     try:
         while True:
+            await asyncio.sleep(0.2)
             print("running")
-            await asyncio.sleep(0.3)
+
     except asyncio.CancelledError:
         print("cancelled")
         await asyncio.sleep(0.1)
@@ -19,9 +28,12 @@ async def run():
 
 
 s = Synchronizer()
+
 blocking_run = s.create_blocking(run)
 
+
 try:
-    asyncio.run(blocking_run.aio())
+    with Runner() as runner:
+        runner.run(blocking_run.aio())
 except KeyboardInterrupt:
     print("keyboard interrupt")

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -115,7 +115,7 @@ async def test_function_many_parallel_async(synchronizer):
 
 async def gen(n):
     for i in range(n):
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(SLEEP_DELAY)
         yield i
 
 

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import synchronicity
 from synchronicity import Synchronizer
 
-SLEEP_DELAY = 0.1
+SLEEP_DELAY = 0.5
 
 
 async def f(x):

--- a/test/type_stub_e2e_test.py
+++ b/test/type_stub_e2e_test.py
@@ -84,6 +84,7 @@ def test_mypy_assertions(interface_file):
         ),
     ],
 )
+@pytest.mark.skipif(sys.platform == "win32", reason="temp_assertion_file permissions issues on github actions (windows)")
 def test_failing_assertion(interface_file, failing_assertion, error_matches):
     # since there appears to be no good way of asserting failing type checks (and skipping to the next assertion)
     # we use the assertion file as a template to insert statements that should fail type checking

--- a/test/type_stub_e2e_test.py
+++ b/test/type_stub_e2e_test.py
@@ -84,7 +84,9 @@ def test_mypy_assertions(interface_file):
         ),
     ],
 )
-@pytest.mark.skipif(sys.platform == "win32", reason="temp_assertion_file permissions issues on github actions (windows)")
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="temp_assertion_file permissions issues on github actions (windows)"
+)
 def test_failing_assertion(interface_file, failing_assertion, error_matches):
     # since there appears to be no good way of asserting failing type checks (and skipping to the next assertion)
     # we use the assertion file as a template to insert statements that should fail type checking


### PR DESCRIPTION
Windows can't interrupt the underlying syscall when waiting for a concurrent.futures.Future result, so we have to yield control to the python interpreter once in a while, to detect ctrl-c/keyboard interrupts when it occurs.

This means, previously, a long running synchronicity blocking call (like a func.remote() call in `modal run`) was not ctrl-c:able on windows.

This adds fix + CI workflows that test synchronicity on mac and windows.

NOTE: it appears that this introduced a bunch more test flake in the shutdown tests, which is super hard to reproduce locally for me (I was able to get like 1 failure in 1000 runs). See https://github.com/modal-labs/synchronicity/pull/180 which is based of this branch and changes some small things, but triggered a bunch of test failures