### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.8.3"
+version = "0.9.0"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Increasing minor version instead of patch, just to ensure we don't auto upgrade patch versions in case the new packaging or 'polling' future waits break something unexpected
