### PR TITLE
Don't export Interface from top level package

### DIFF
--- a/src/synchronicity/__init__.py
+++ b/src/synchronicity/__init__.py
@@ -1,2 +1,3 @@
-from .interface import Interface  # noqa: F401
-from .synchronizer import Synchronizer  # noqa: F401
+from .synchronizer import Synchronizer
+
+__all__ = ["Synchronizer"]

--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -25,8 +25,9 @@ import typing_extensions
 from sigtools._signatures import EmptyAnnotation, UpgradedAnnotation, UpgradedParameter  # type: ignore
 
 import synchronicity
-from synchronicity import Interface, combined_types, overload_tracking
+from synchronicity import combined_types, overload_tracking
 from synchronicity.annotations import evaluated_annotation
+from synchronicity.interface import Interface
 from synchronicity.synchronizer import (
     SYNCHRONIZER_ATTR,
     TARGET_INTERFACE_ATTR,
@@ -120,11 +121,11 @@ def _get_type_vars(typ, synchronizer, home_module):
     ret = set()
     if isinstance(typ, typing.TypeVar):
         # check if it's translated (due to bounds= attributes etc.)
-        typ = synchronizer._translate_out(typ, Interface.BLOCKING)
+        typ = synchronizer._translate_out(typ)
         ret.add(typ)
     elif isinstance(typ, (typing_extensions.ParamSpecArgs, typing_extensions.ParamSpecKwargs)):
         param_spec = origin
-        param_spec = synchronizer._translate_out(param_spec, Interface.BLOCKING)
+        param_spec = synchronizer._translate_out(param_spec)
         ret.add(param_spec)
     elif origin:
         for arg in typing.get_args(typ):

--- a/test/async_wrap_test.py
+++ b/test/async_wrap_test.py
@@ -1,8 +1,9 @@
 import inspect
 import typing
 
-from synchronicity import Interface, async_wrap
+from synchronicity import async_wrap
 from synchronicity.async_wrap import wraps_by_interface
+from synchronicity.interface import Interface
 from synchronicity.synchronizer import FunctionWithAio
 
 

--- a/test/pickle_test.py
+++ b/test/pickle_test.py
@@ -1,7 +1,7 @@
 import pickle
 import pytest
 
-from synchronicity import Interface
+from synchronicity.interface import Interface
 
 
 class PicklableClass:

--- a/test/type_stub_translation_test.py
+++ b/test/type_stub_translation_test.py
@@ -1,7 +1,8 @@
 import pytest
 import typing
 
-from synchronicity import Interface, Synchronizer, combined_types
+from synchronicity import Synchronizer, combined_types
+from synchronicity.interface import Interface
 from synchronicity.type_stubs import StubEmitter
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "synchronicity"
-version = "0.8.3"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "sigtools", marker = "python_full_version >= '3.8' or platform_python_implementation == 'CPython'" },


### PR DESCRIPTION
Since the package is now declared as `py.typed` it fails type checking on `from synchronicity import Synchronizer` unless we put `__all__` in the init file. And explicit use of `Interface` is now deprecated, so removing that from the top level package exports...