### PR TITLE
Make type stubs generated on Python 3.13 backwards compatible

### DIFF
--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -733,10 +733,15 @@ class StubEmitter:
                 # e.g. first argument to typing.Callable
                 subargs = ",".join([self._formatannotation(arg) for arg in annotation])
                 return f"[{subargs}]"
+
             return repr(annotation)
 
         # generic:
         origin_name = get_specific_generic_name(annotation)
+        if origin is contextlib.AbstractAsyncContextManager:
+            # python 3.13 adds a second optional exit arg, we only want to emit the first one
+            # to be backwards compatible
+            args = args[:1]
 
         if (safe_get_module(annotation), origin_name) == ("typing", "Optional"):
             # typing.Optional adds a None argument that we shouldn't include when formatting

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -283,12 +283,9 @@ def test_synchronicity_type_translation():
     print(src)
     assert "class __get_foo_spec(typing_extensions.Protocol):" in src
     assert "    def __call__(self, foo: Foo) -> synchronicity.combined_types.AsyncAndBlockingContextManager[Foo]" in src
-    if sys.version_info < (3, 13):
-        expected_original_repr = "typing.AsyncContextManager[Foo]"
-    else:
-        # python 3.13 has an exit type generic argument to context managers
-        expected_original_repr = "typing.AsyncContextManager[Foo, bool | None]"
-    assert f"    async def aio(self, foo: Foo) -> {expected_original_repr}" in src
+    # python 3.13 has an exit type generic argument, e.g. typing.AsyncContextManager[Foo, bool | None]
+    # but we want the type stubs to work on older versions of python too (without conditionals everywhere):
+    assert "    async def aio(self, foo: Foo) -> typing.AsyncContextManager[Foo]" in src
     assert "get_foo: __get_foo_spec"
 
 


### PR DESCRIPTION
Slightly different version of 3.13 compatibility, just skipping the exit argument type for now