### PR TITLE
Add aclose to _BUILTIN_ASYNC_METHODS

### DIFF
--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -30,7 +30,7 @@ _BUILTIN_ASYNC_METHODS = {
     "__aenter__": "__enter__",
     "__aexit__": "__exit__",
     "__anext__": "__next__",
-    "aclose": "close"
+    "aclose": "close",
 }
 
 IGNORED_ATTRIBUTES = (

--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -30,6 +30,7 @@ _BUILTIN_ASYNC_METHODS = {
     "__aenter__": "__enter__",
     "__aexit__": "__exit__",
     "__anext__": "__next__",
+    "aclose": "close"
 }
 
 IGNORED_ATTRIBUTES = (

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -473,6 +473,7 @@ async def test_non_async_aiter(synchronizer):
     # check sync iteration on the wrapped iterator
     it = WrappedIt()
     assert list(it) == ["foo", "bar"]
+    it.close()
 
 
 def test_generic_baseclass():

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -455,15 +455,20 @@ async def test_non_async_aiter(synchronizer):
             value = await self._gen.__anext__()
             return value
 
+        async def aclose(self):
+            await self._gen.aclose()
+
     WrappedIt = synchronizer.create_blocking(It, name="WrappedIt")
 
     # just a sanity check of the original iterable:
     orig_async_it = It()
     assert [v async for v in orig_async_it] == ["foo", "bar"]
+    await orig_async_it.aclose()
 
     # check async iteration on the wrapped iterator
     it = WrappedIt()
     assert [v async for v in it] == ["foo", "bar"]
+    await it.aclose()
 
     # check sync iteration on the wrapped iterator
     it = WrappedIt()


### PR DESCRIPTION
This pr adds aclose to the list of builtin async methods. This is to allow classes like `StreamReader` to implement `aclose` in a way that's compatible with the recent `async_utils` changes.
