### PR TITLE
Fix issue when generic base classes had multiple generic type vars

### DIFF
--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -660,7 +660,7 @@ class Synchronizer:
             else:
                 if base_is_generic:
                     wrapped_generic = self._wrap(base.__origin__, interface, require_already_wrapped=(name is not None))
-                    new_bases.append(wrapped_generic.__class_getitem__(*base.__args__))
+                    new_bases.append(wrapped_generic.__class_getitem__(base.__args__))
                 else:
                     new_bases.append(self._wrap(base, interface, require_already_wrapped=(name is not None)))
 

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -500,7 +500,7 @@ def test_generic_baseclass():
         pass
 
     WrappedGenericSubclass = s.create_blocking(GenericSubclass, name="BlockingGenericSubclass")
-    assert WrappedGenericSubclass[bool, int].__args__ == (str, float)
+    assert WrappedGenericSubclass[bool, int].__args__ == (bool, int)
     instance_2 = WrappedGenericSubclass()
     assert isinstance(instance_2, WrappedGenericSubclass)
     assert isinstance(instance_2, WrappedGenericClass)  # still instance of parent

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -478,16 +478,33 @@ async def test_non_async_aiter(synchronizer):
 
 def test_generic_baseclass():
     T = typing.TypeVar("T")
+    V = typing.TypeVar("V")
 
-    class GenericClass(typing.Generic[T]):
+    class GenericClass(typing.Generic[T, V]):
         async def do_something(self):
             return 1
 
-    s = synchronicity.Synchronizer(multiwrap_warning=False)
+    s = synchronicity.Synchronizer()
     WrappedGenericClass = s.create_blocking(GenericClass, name="BlockingGenericClass")
-    instance: WrappedGenericClass[str] = WrappedGenericClass()  #  should be allowed
+
+    assert WrappedGenericClass[str, float].__args__ == (str, float)
+
+    instance: WrappedGenericClass[str, float] = WrappedGenericClass()  #  should be allowed
     assert isinstance(instance, WrappedGenericClass)
     assert instance.do_something() == 1
+
+    Q = typing.TypeVar("O")
+    Y = typing.TypeVar("Y")
+
+    class GenericSubclass(GenericClass[Q, Y]):
+        pass
+
+    WrappedGenericSubclass = s.create_blocking(GenericSubclass, name="BlockingGenericSubclass")
+    assert WrappedGenericSubclass[bool, int].__args__ == (str, float)
+    instance_2 = WrappedGenericSubclass()
+    assert isinstance(instance_2, WrappedGenericSubclass)
+    assert isinstance(instance_2, WrappedGenericClass)  # still instance of parent
+    assert instance.do_something() == 1  # has base methods
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`__class_getitem__` always takes a single argument which can either be a single item or a tuple - not a variadic.

This previously broke the wrapping code if a generic base class (that wasn't `typing.Generic` itself) had multiple `__args__`.