### PR TITLE
Add support for _typeshed and update CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest"]
         include:
-          - os: "macos-12" # x86-64
+          - os: "macos-13" # x86-64
             python-version: "3.10"
           - os: "macos-14" # ARM64 (M1)
             python-version: "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false # run all variants across python versions/os to completion
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-latest"]
         include:
           - os: "macos-12" # x86-64

--- a/src/synchronicity/annotations.py
+++ b/src/synchronicity/annotations.py
@@ -2,12 +2,14 @@
 import importlib
 import logging
 import sys
+import typing
 
 logger = logging.getLogger("synchronicity")
 
 # Modules that cannot be evaluated at runtime, e.g.,
 # only available under the TYPE_CHECKING guard, but can be used freely in stub files
 TYPE_CHECKING_OVERRIDES = {"_typeshed"}
+
 
 def evaluated_annotation(annotation, *, globals_=None, declaration_module=None):
     # evaluate string annotations...
@@ -31,7 +33,6 @@ def evaluated_annotation(annotation, *, globals_=None, declaration_module=None):
             # return a ForwardRef with __forward_module__ set
             # to the name of the module that we want to import in the stub file
             if ref_module in TYPE_CHECKING_OVERRIDES:
-                import typing
                 ref = typing.ForwardRef(annotation)
                 ref.__forward_module__ = ref_module
                 return ref

--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -26,7 +26,7 @@ from sigtools._signatures import EmptyAnnotation, UpgradedAnnotation, UpgradedPa
 
 import synchronicity
 from synchronicity import combined_types, overload_tracking
-from synchronicity.annotations import evaluated_annotation
+from synchronicity.annotations import TYPE_CHECKING_OVERRIDES, evaluated_annotation
 from synchronicity.interface import Interface
 from synchronicity.synchronizer import (
     SYNCHRONIZER_ATTR,
@@ -702,7 +702,7 @@ class StubEmitter:
         # but can be used freely in stub files, import the module and return the
         # original annotation
         if isinstance(annotation, typing.ForwardRef):
-            if hasattr(annotation, "__forward_module__") and annotation.__forward_module__ is not None:
+            if hasattr(annotation, "__forward_module__") and annotation.__forward_module__ in TYPE_CHECKING_OVERRIDES:
                 self.imports.add(annotation.__forward_module__)
                 return annotation.__forward_arg__
 

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -619,3 +619,15 @@ def test_paramspec_args():
         "def foo(fn: typing.Callable[test.type_stub_helpers.some_mod.P, None], *args: test.type_stub_helpers.some_mod.P.args, **kwargs: test.type_stub_helpers.some_mod.P.kwargs) -> str:"  # noqa
         in src
     )  # noqa: E501
+
+if typing.TYPE_CHECKING:
+    import _typeshed
+
+def test_typeshed():
+    """Test that _typeshed annotations are preserved in stubs."""
+    def foo() -> "_typeshed.OpenTextMode":
+        return "r"
+
+    src = _function_source(foo)
+    assert "import _typeshed" in src
+    assert "def foo() -> _typeshed.OpenTextMode:" in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -620,11 +620,14 @@ def test_paramspec_args():
         in src
     )  # noqa: E501
 
+
 if typing.TYPE_CHECKING:
     import _typeshed
 
+
 def test_typeshed():
     """Test that _typeshed annotations are preserved in stubs."""
+
     def foo() -> "_typeshed.OpenTextMode":
         return "r"
 


### PR DESCRIPTION
This pr adds support for importing packages like [_typeshed](https://github.com/python/typeshed/tree/main/stdlib/_typeshed) with `synchronicity`. Packages like `_typeshed` do not exist at runtime, so they cannot be evaluated normally. However, they can be used in stubs, i.e., `.pyi` files.

Here is an intended use-case for `_typeshed` in `modal-client` that would not work without this pr:
```python
if typing.TYPE_CHECKING:
    import _typeshed

# function for file opens with file modes
def sandbox_open(mode: "_typeshed.OpenTextMode"): ...
```
Before this pr, this won't compile, as `synchronicity` relies on a runtime `eval` of parent modules to get definitions. For modules like `_typeshed`, which don't exist at runtime, we should instead preserve the forward reference and import the package directly. 

After this pr, the function should compile to the following stub:
```python
import _typeshed
def sandbox_open(mode: _typeshed.OpenTextMode): ...
```

This pr also makes some changes to CI checks: 
- removes python `3.8`, as this version is no longer supported by `modal-client` (note — this is tied to this pr as the `__forward_module__` workaround implemented here doesn't work in `3.8`)
- updates `macOS 12` to `macOS 13`, since `macOS 12` has been deprecated by GitHub actions