### PR TITLE
Bump version to 0.9.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.9.6"
+version = "0.9.7"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bumps the version to 0.9.7 in prep for a new release.

(I don't actually know how to do the subsequent steps 🙈)