### PR TITLE
Fix unwrapping exceptions from decorated functions

### DIFF
--- a/src/synchronicity/async_wrap.py
+++ b/src/synchronicity/async_wrap.py
@@ -20,7 +20,7 @@ def wraps_by_interface(interface: Interface, func):
 
     Note: Does not forward async generator information other than explicit annotations
     """
-    if inspect.iscoroutinefunction(func) and interface == Interface._ASYNC_WITH_BLOCKING_TYPES:
+    if is_coroutine_function_follow_wrapped(func) and interface == Interface._ASYNC_WITH_BLOCKING_TYPES:
 
         def asyncfunc_deco(user_wrapper):
             @functools.wraps(func)


### PR DESCRIPTION
Fixes an issue introduced in #194 where synchronicity would raise its internal `UserCodeException` class when exceptions were triggered within:

- async functions
- wrapped with a decorator
- invoked via the `.aio` interface

The correct behavior would be to unwrap the `UserCodeException` and propagate the underlying exception.