### PR TITLE
Updated docs to reflect latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,5 @@ jobs:
         run: uv sync --group=dev
       - name: Run tests with pytest
         run: uv run --group=dev pytest -s
+      - name: Run README tests
+        run: uv run --group=dev pytest --markdown-docs README.md

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Gotchas
 
     ```py
     @synchronizer.wrap
-    def foo() -> typing.AsyncContextManager[str]
+    def foo() -> typing.AsyncContextManager[str]:
         return make_context_manager() 
     ```
 * If a class is "synchronized", any instance of that class will be a proxy for an instance of the original class. Methods on the class will delegate to methods of the underlying class, but *attributes* of the original class aren't directly reachable and would need getter methods or @properties to be reachable on the wrapper.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ A common pitfall in asynchronous programming is to accidentally lock up an event
 ```python
 import time
 
-@synchronizer.wrap()
+@synchronizer.wrap
 async def buggy_library():
     time.sleep(0.1)  #non-async sleep, this locks the library's event loop for the duration
     

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import typing
 
 from synchronicity import Synchronizer
 
@@ -23,6 +24,7 @@ def quicksleep(monkeypatch):
 def pytest_markdown_docs_globals():
     synchronizer = Synchronizer()
     return {
+        "typing": typing,
         "synchronizer": synchronizer,
         "asyncio": asyncio,
         "connect_to_database": dummy_connect_to_db,

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from synchronicity import Synchronizer
+
+
+class DummyConnection:
+    async def run_query(self, query):
+        pass
+
+
+async def dummy_connect_to_db(url):
+    return DummyConnection()
+
+
+def pytest_markdown_docs_globals():
+    synchronizer = Synchronizer()
+    return {
+        "synchronizer": synchronizer,
+        "asyncio": asyncio,
+        "connect_to_database": dummy_connect_to_db,
+    }

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 
 from synchronicity import Synchronizer
 
@@ -10,6 +11,13 @@ class DummyConnection:
 
 async def dummy_connect_to_db(url):
     return DummyConnection()
+
+
+@pytest.fixture()
+def quicksleep(monkeypatch):
+    from asyncio import sleep as original_sleep
+
+    monkeypatch.setattr("asyncio.sleep", lambda x: original_sleep(x / 1000.0))
 
 
 def pytest_markdown_docs_globals():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,5 @@ test = [
     "gevent>=24.2.1; python_version < '3.13'",
     "pytest>=8.3.3",
     "pytest-asyncio>=0.24.0",
+    "pytest-markdown-docs>=0.7.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.9.10"
+version = "0.9.11"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 authors = [

--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -821,6 +821,10 @@ class Synchronizer:
 
     # New interface that (almost) doesn't mutate objects
     def create_blocking(self, obj, name: Optional[str] = None, target_module: Optional[str] = None):
+        # TODO: deprecate this alias method
+        return self.wrap(obj, name, target_module)
+
+    def wrap(self, obj, name: Optional[str] = None, target_module: Optional[str] = None):
         wrapped = self._wrap(obj, Interface.BLOCKING, name, target_module=target_module)
         return wrapped
 

--- a/test/asynccontextmanager_test.py
+++ b/test/asynccontextmanager_test.py
@@ -1,3 +1,4 @@
+import contextlib
 import pytest
 import typing
 
@@ -116,4 +117,21 @@ async def test_asynccontextmanager_with_in_async(synchronizer):
     # err_cls = AttributeError if sys.version_info < (3, 11) else TypeError
     # with pytest.raises(err_cls):
     with r.wrap.aio():  # TODO: this *should* not be allowed, but works for stupid reasons
+        pass
+
+
+@pytest.mark.asyncio
+async def test_returning_context_manager(synchronizer):
+    @contextlib.asynccontextmanager
+    async def foo():
+        yield "hello"
+
+    @synchronizer.wrap
+    def returner() -> typing.AsyncContextManager[str]:
+        return foo()
+
+    with returner():
+        pass
+
+    async with returner.aio():
         pass

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -29,7 +29,7 @@ def test_function_sync(synchronizer):
     assert f_s.__name__ == "blocking_f"
     ret = f_s(42)
     assert ret == 1764
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
 
 def test_function_sync_future(synchronizer):
@@ -40,7 +40,7 @@ def test_function_sync_future(synchronizer):
     assert isinstance(fut, concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
     assert fut.result() == 1764
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
 
 @pytest.mark.asyncio
@@ -53,7 +53,7 @@ async def test_function_async_as_function_attribute(synchronizer):
     assert inspect.iscoroutine(coro)
     assert time.time() - t0 < SLEEP_DELAY
     assert await coro == 1764
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
     # Make sure the same-loop calls work
     f2_s = s.create_blocking(f2).aio
@@ -89,7 +89,7 @@ def test_function_many_parallel_sync(synchronizer):
     g = synchronizer.create_blocking(f)
     t0 = time.time()
     rets = [g(i) for i in range(10)]  # Will resolve serially
-    assert len(rets) * SLEEP_DELAY < time.time() - t0 < (len(rets) + 1) * SLEEP_DELAY
+    assert len(rets) * SLEEP_DELAY <= time.time() - t0 < (len(rets) + 1) * SLEEP_DELAY
 
 
 def test_function_many_parallel_sync_futures(synchronizer):
@@ -99,7 +99,7 @@ def test_function_many_parallel_sync_futures(synchronizer):
     assert isinstance(futs[0], concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
     assert [fut.result() for fut in futs] == [z**2 for z in range(100)]
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
 
 @pytest.mark.asyncio
@@ -110,7 +110,7 @@ async def test_function_many_parallel_async(synchronizer):
     assert inspect.iscoroutine(coros[0])
     assert time.time() - t0 < SLEEP_DELAY
     assert await asyncio.gather(*coros) == [z**2 for z in range(100)]
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
 
 async def gen(n):
@@ -269,16 +269,16 @@ def test_class_sync(synchronizer):
     t0 = time.time()
     with obj as z:
         assert z == 42
-        assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+        assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
     assert time.time() - t0 > 2 * SLEEP_DELAY
 
     t0 = time.time()
     assert BlockingMyClass.my_static_method() == 43
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
     t0 = time.time()
     assert BlockingMyClass.my_class_method() == 44
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
     assert list(z for z in obj) == list(range(42))
 
@@ -319,7 +319,7 @@ async def test_class_async_as_method_attribute(synchronizer):
     t0 = time.time()
     async with obj as z:
         assert z == 42
-        assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+        assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
     assert time.time() - t0 > 2 * SLEEP_DELAY
 
@@ -339,7 +339,7 @@ def test_event_loop(synchronizer):
     t0 = time.time()
     f_s = synchronizer.create_blocking(f)
     assert f_s(42) == 42 * 42
-    assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
     assert synchronizer._thread.is_alive()
     assert synchronizer._loop.is_running()
     synchronizer._close_loop()


### PR DESCRIPTION
Cleanup of docs

* Introduces the `synchronizer.wrap` as a more natural spelling for the legacy-vibe `synchronizer.create_blocking`
* Updates README to reflect last few years of updates to Synchronicity (there were a few outdated suggestions as pointed to by https://github.com/modal-labs/synchronicity/issues/141 - sorry!)
* Adds pytest-markdown-docs to CI to automatically check the validity of the readme snippets
