### PR TITLE
Type stubs: fixes issue with positional-only args + synchronizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.9.11"
+version = "0.9.12"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 authors = [

--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -83,7 +83,7 @@ def add_prefix_arg(arg_name, remove_args=0):
         parameters = list(sig.parameters.values())
         return sig.replace(
             parameters=[
-                UpgradedParameter(arg_name, inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                UpgradedParameter(arg_name, inspect.Parameter.POSITIONAL_ONLY),
                 *parameters[remove_args:],
             ]
         )

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -645,3 +645,13 @@ def test_typeshed():
     src = _function_source(foo)
     assert "import _typeshed" in src
     assert "def foo() -> _typeshed.OpenTextMode:" in src
+
+
+def test_positional_only_wrapped_function(synchronizer):
+    @synchronizer.wrap
+    async def f(pos_only=None, /, **kwargs): ...
+
+    # The following used to crash because the injected `self` in the generated Protocol
+    # didn't use the positional-only qualifier
+    src = _function_source(f)
+    assert "def __call__(self, pos_only=None, /, **kwargs):" in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -292,10 +292,12 @@ def test_synchronicity_type_translation():
 
     print(src)
     assert "class __get_foo_spec(typing_extensions.Protocol):" in src
-    assert "    def __call__(self, foo: Foo) -> synchronicity.combined_types.AsyncAndBlockingContextManager[Foo]" in src
+    assert (
+        "    def __call__(self, /, foo: Foo) -> synchronicity.combined_types.AsyncAndBlockingContextManager[Foo]" in src
+    )
     # python 3.13 has an exit type generic argument, e.g. typing.AsyncContextManager[Foo, bool | None]
     # but we want the type stubs to work on older versions of python too (without conditionals everywhere):
-    assert "    async def aio(self, foo: Foo) -> typing.AsyncContextManager[Foo]" in src
+    assert "    async def aio(self, /, foo: Foo) -> typing.AsyncContextManager[Foo]" in src
     assert "get_foo: __get_foo_spec"
 
 
@@ -304,8 +306,8 @@ def test_synchronicity_wrapped_class():
     print(src)
     # assert "__init__" not in Foo
     assert "class __clone_spec(typing_extensions.Protocol):" in src
-    assert "    def __call__(self, foo: Foo) -> Foo" in src
-    assert "    async def aio(self, foo: Foo) -> Foo" in src
+    assert "    def __call__(self, /, foo: Foo) -> Foo" in src
+    assert "    async def aio(self, /, foo: Foo) -> Foo" in src
     assert "clone: __clone_spec" in src
 
 
@@ -330,10 +332,10 @@ def test_synchronicity_class():
     assert (
         """
     class __meth_spec(typing_extensions.Protocol[SUPERSELF]):
-        def __call__(self, arg: bool) -> int:
+        def __call__(self, /, arg: bool) -> int:
             ...
 
-        async def aio(self, arg: bool) -> int:
+        async def aio(self, /, arg: bool) -> int:
             ...
 
     meth: __meth_spec[typing_extensions.Self]
@@ -384,8 +386,10 @@ def test_paramspec_generic():
     assert "class BlockingParamSpecGeneric(typing.Generic[Translated_P, Translated_T])" in src
 
     assert "class __meth_spec(typing_extensions.Protocol[Translated_P_INNER, SUPERSELF]):" in src
-    assert "def __call__(self, *args: Translated_P_INNER.args, **kwargs: Translated_P_INNER.kwargs) -> SUPERSELF" in src
-    assert "def aio(self, *args: Translated_P_INNER.args, **kwargs: Translated_P_INNER.kwargs) -> SUPERSELF" in src
+    assert (
+        "def __call__(self, /, *args: Translated_P_INNER.args, **kwargs: Translated_P_INNER.kwargs) -> SUPERSELF" in src
+    )
+    assert "def aio(self, /, *args: Translated_P_INNER.args, **kwargs: Translated_P_INNER.kwargs) -> SUPERSELF" in src
     assert "meth: __meth_spec[Translated_P, typing_extensions.Self]" in src
     assert "def syncfunc(self) -> Translated_T:" in src
 
@@ -407,8 +411,8 @@ def test_synchronicity_generic_subclass():
 
     foo = synchronizer.create_blocking(foo_impl, "foo")
     src = _function_source(foo)
-    assert "def __call__(self, bar: BlockingMyGeneric[str]):" in src
-    assert "async def aio(self, bar: BlockingMyGeneric[str]):" in src
+    assert "def __call__(self, /, bar: BlockingMyGeneric[str]):" in src
+    assert "async def aio(self, /, bar: BlockingMyGeneric[str]):" in src
 
 
 _B = typing.TypeVar("_B", bound="str")
@@ -523,7 +527,7 @@ def test_wrapped_context_manager_is_both_blocking_and_async():
     wrapped_foo_src = _function_source(wrapped_foo)
 
     assert (
-        "def __call__(self, arg: int) -> synchronicity.combined_types.AsyncAndBlockingContextManager[str]:"
+        "def __call__(self, /, arg: int) -> synchronicity.combined_types.AsyncAndBlockingContextManager[str]:"
         in wrapped_foo_src
     )
     assert "AbstractAsyncContextManager" not in wrapped_foo_src
@@ -572,7 +576,7 @@ def test_returns_forward_wrapped_generic():
     assert "class Container(typing.Generic[Translated_T]):" in src
     assert "Translated_T_INNER = typing.TypeVar" in src  # distinct "inner copy" of Translated_T needs to be declared
     assert "typing_extensions.Protocol[Translated_T_INNER, SUPERSELF]" in src
-    assert "def __call__(self) -> ReturnVal[Translated_T_INNER]:" in src
+    assert "def __call__(self, /) -> ReturnVal[Translated_T_INNER]:" in src
     assert "fun: __fun_spec[Translated_T, typing_extensions.Self]" in src
 
 


### PR DESCRIPTION
Previously, a Synchronizer wrapping a function with positional-only args would crash the type stub generator, since the injected `self` in the Protocol of the type stub 'dual' function would not be qualified as positional only, but the following argument was
