### PR TITLE
Fixes a thread race when cancelling an async call across threads

### DIFF
--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -387,8 +387,15 @@ class Synchronizer:
             except asyncio.CancelledError:
                 if a_fut.cancelled():
                     raise  # cancellation came from within c_fut
-                loop.call_soon_threadsafe(coro_task.cancel)  # cancel inner task
-                value = await a_fut  # typically also yields a cancellation error
+                loop.call_soon_threadsafe(coro_task.cancel)  # cancel task on synchronizer event loop
+                # wait for cancellation logic in the underlying coro to complete
+                # this should typically raise CancelledError, but in case of either
+                # cancellation prevention in the coro OR if the underlying task
+                # has already completed, it could return a value. In the latter
+                # case this could lead to unexpected aborted cancellations in the
+                # caller
+                await a_fut  # wait for cancellation logic to complete - this typically raises CancelledError
+                raise  # re-raise the CancelledError regardless - preventing unintended cancellation aborts
 
         if getattr(original_func, self._output_translation_attr, True):
             return self._translate_out(value)

--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -389,12 +389,11 @@ class Synchronizer:
                     raise  # cancellation came from within c_fut
                 loop.call_soon_threadsafe(coro_task.cancel)  # cancel task on synchronizer event loop
                 # wait for cancellation logic in the underlying coro to complete
-                # this should typically raise CancelledError, but in case of either
-                # cancellation prevention in the coro OR if the underlying task
-                # has already completed, it could return a value. In the latter
-                # case this could lead to unexpected aborted cancellations in the
-                # caller
-                await a_fut  # wait for cancellation logic to complete - this typically raises CancelledError
+                # this should typically raise CancelledError, but in case of either:
+                # * cancellation prevention in the coro (catching the cancellederror)
+                # * coro_task resolves before the call_soon_threadsafe above is scheduled
+                # the cancellation in a_fut would be cancelled
+                await a_fut  # wait for cancellation logic to complete - this *normally* raises CancelledError
                 raise  # re-raise the CancelledError regardless - preventing unintended cancellation aborts
 
         if getattr(original_func, self._output_translation_attr, True):


### PR DESCRIPTION
There could previously be races when making async calls across threads, e.g, aborting cancellations in unexpected ways that wouldn't appear for single-threaded event loop code, e.g.:

```py
@synchronizer.wrap
def well_behaved():
    await something()
    return "success"

async def main_thread():
    t = asyncio.create_task(well_behaved.aio())
    await asyncio.sleep(0)  # start up the task - stopping at `await something()` above
    t.cancel()
    # unlike "normal" asyncio code - there can be a race here where `well_behaved` resolves to "success"
    # here, even though a cancellation has been scheduled in the calling event loop, since the cancellation
    # in the synchronizer loop is not necessarily scheduled yet (it will do a `call_soon_threadsafe(cancel)`)
    await t  
```

This "fixes" the issue by always re-raising CancelledError in the caller after a cancellation has been scheduled, regardless what the underlying result is (but we do wait for the result to propagate first).

This has the side effect that it removes the possibility to fully abort a cancellation in a synchronizer-wrapped method. You can still catch and handle cancellations in the wrapped code, and the await in the caller thread will not resolve until the cancellation completes, but with this change the calling thread will always receive a CancelledError even if the called code doesn't reraise it. Aborting a cancellation fully is pretty bad form though, and dangerous, so I don't think this is too restricting.

----
Note that similar issues where tasks resolve instead of raising cancellations could arise in single-event-loop async code, but *only* if control is yielded such that the task resolves *before* .cancel() is called, e.g:
```
t = asyncio.create_task(resolves_immediately())
await something()  # during this, t will be resolved
t.cancel()  # this will have no effect since t is already done
await t # not raising
```