### PR TITLE
Adds regression test that type of .aio() return values are consistent

### DIFF
--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -592,3 +592,21 @@ async def test_async_cancel_completes_successfully_still_cancels(synchronizer):
     # task would race a cancellation error in the next await of that task:
     with pytest.raises(asyncio.CancelledError):
         await local_task
+
+
+def test_async_inner_still_translates(synchronizer):
+    class _V:
+        pass
+
+    V = synchronizer.wrap(_V)
+
+    @synchronizer.wrap
+    async def inner():
+        return _V()
+
+    @synchronizer.wrap
+    async def outer():
+        v = await inner.aio()
+        assert isinstance(v, V)
+
+    outer()


### PR DESCRIPTION
I was a bit confused about what the expected result should be when thinking about this, and realized there were no tests that codified it

I think it makes sense that the return type is still returning translated entities when calling a synchronized thing inside the synchronizer event loop - the only thing that should change is that any coroutines are awaited directly rather than going via concurrent.futures thread-synchronization
