### PR TITLE
Propagate docstrings to type stub files

### DIFF
--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -508,7 +508,7 @@ class StubEmitter:
     def _get_docstring(self, obj: object, indentation: str) -> str:
         docstring = inspect.getdoc(obj) or ""
         if docstring:
-            end = "\n" if len(docstring.split("\n")) > 1 else ""
+            end = "\n" if "\n" in docstring else ""  # Place end-quotes appropriately
             if '"""' in docstring:
                 if "'''" in docstring:
                     warnings.warn(

--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -16,6 +16,7 @@ import inspect
 import sys
 import textwrap
 import typing
+import warnings
 from logging import getLogger
 from pathlib import Path
 from typing import TypeVar
@@ -508,8 +509,16 @@ class StubEmitter:
         docstring = inspect.getdoc(obj) or ""
         if docstring:
             end = "\n" if len(docstring.split("\n")) > 1 else ""
-            trips = "'''" if '"""' in docstring else '"""'
-            docstring = textwrap.indent(f"{trips}{docstring}{end}{trips}", indentation)
+            if '"""' in docstring:
+                if "'''" in docstring:
+                    warnings.warn(
+                        f"Docstring for {obj} contains both \"\"\" and ''' quote blocks; suppressing from type stubs."
+                    )
+                    return ""
+                quotes = "'''"
+            else:
+                quotes = '"""'
+            docstring = textwrap.indent(f"{quotes}{docstring}{end}{quotes}", indentation)
         return docstring
 
     def _ensure_import(self, typ):

--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -14,6 +14,7 @@ import enum
 import importlib
 import inspect
 import sys
+import textwrap
 import typing
 from logging import getLogger
 from pathlib import Path
@@ -266,6 +267,9 @@ class StubEmitter:
             self.parts.append(inspect.getsource(cls))
             return
 
+        body_indent_level = 1
+        body_indent = self._indent(body_indent_level)
+
         bases = []
         generic_type_vars: typing.Set[type] = set()
         for b in self._get_translated_class_bases(cls):
@@ -276,14 +280,13 @@ class StubEmitter:
 
         bases_str = "" if not bases else "(" + ", ".join(bases) + ")"
         decl = f"class {name}{bases_str}:"
+        class_docstring = self._get_docstring(cls, body_indent)
+
         var_annotations = []
         methods = []
 
         annotations = cls.__dict__.get("__annotations__", {})
         annotations = {k: self._translate_global_annotation(annotation, cls) for k, annotation in annotations.items()}
-
-        body_indent_level = 1
-        body_indent = self._indent(body_indent_level)
 
         for varname, annotation in annotations.items():
             var_annotations.append(f"{body_indent}{self._get_var_annotation(varname, annotation)}")
@@ -339,6 +342,7 @@ class StubEmitter:
             "\n".join(
                 [
                     decl,
+                    class_docstring,
                     *var_annotations,
                     *methods,
                     *padding,
@@ -499,6 +503,14 @@ class StubEmitter:
         import_src = "\n".join(sorted(f"import {mod}" for mod in self.imports))
         stubs = "\n\n".join(self.parts)
         return f"{import_src}\n\n{stubs}".lstrip()
+
+    def _get_docstring(self, obj: object, indentation: str) -> str:
+        docstring = inspect.getdoc(obj) or ""
+        if docstring:
+            end = "\n" if len(docstring.split("\n")) > 1 else ""
+            trips = "'''" if '"""' in docstring else '"""'
+            docstring = textwrap.indent(f"{trips}{docstring}{end}{trips}", indentation)
+        return docstring
 
     def _ensure_import(self, typ):
         # add import for a single type, non-recursive (See _register_imports)
@@ -846,6 +858,7 @@ class StubEmitter:
                 signature_indent,
                 body_indent,
                 transform_signature=transform_signature,
+                add_docstring=False,
             )
             parts.append(overload_src)
 
@@ -869,6 +882,7 @@ class StubEmitter:
         signature_indent: str,
         body_indent: str,
         transform_signature=None,
+        add_docstring=True,
     ) -> str:
         maybe_decorators = ""
         if hasattr(func, "__dataclass_transform__"):
@@ -901,10 +915,12 @@ class StubEmitter:
             async_prefix = "async "
 
         signature = self._custom_signature(func, transform_signature)
+        maybe_docstring = self._get_docstring(func, body_indent) if add_docstring else ""
 
         return "\n".join(
             [
                 f"{maybe_decorators}{signature_indent}{async_prefix}def {name}{signature}:",
+                *([maybe_docstring] if maybe_docstring else []),
                 f"{body_indent}...",
                 "",
             ]

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -54,6 +54,10 @@ def nested_docstring_func():
     """
 
 
+def deranged_docstring_func():
+    """I have \""" and also ''' for some reason"""
+
+
 class SingleLineDocstringClass:
     """I have a single line docstring"""
 
@@ -732,3 +736,7 @@ def test_docstrings():
     src = _class_source(ClassWithMethodsWithDocstrings)
     assert '        """I have a docstring"""\n' in src
     assert '        """I have a docstring\n\n        with multiple lines\n        """\n' in src
+
+    with pytest.warns(UserWarning, match="both \"\"\" and ''' quote blocks"):
+        src = _function_source(deranged_docstring_func)
+        assert '"""' not in src

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -33,6 +33,49 @@ async def async_func() -> str:
     return "hello"
 
 
+def single_line_docstring_func():
+    """I have a single line docstring"""
+
+
+def multi_line_docstring_func():
+    """I have a docstring
+
+    with multiple lines
+    """
+
+
+def nested_docstring_func():
+    """I have a docstring
+
+    ```
+    def example():
+        \"""SUPRISE! SO DO I!\"""
+    ```
+    """
+
+
+class SingleLineDocstringClass:
+    """I have a single line docstring"""
+
+
+class MultiLineDocstringClass:
+    """I have a docstring
+
+    with multiple lines
+    """
+
+
+class ClassWithMethodsWithDocstrings:
+    def method_with_single_line_docstring(self):
+        """I have a docstring"""
+
+    def method_with_multi_line_docstring(self):
+        """I have a docstring
+
+        with multiple lines
+        """
+
+
 def _function_source(func, target_module=__name__):
     stub_emitter = StubEmitter(target_module)
     stub_emitter.add_function(func, func.__name__)
@@ -667,3 +710,25 @@ def test_positional_only_wrapped_function(synchronizer):
     # didn't use the positional-only qualifier
     src = _function_source(f)
     assert "def __call__(self, pos_only=None, /, **kwargs):" in src
+
+
+def test_docstrings():
+    src = _function_source(single_line_docstring_func)
+    assert '    """I have a single line docstring"""' in src
+
+    src = _function_source(multi_line_docstring_func)
+    assert '    """I have a docstring\n\n    with multiple lines\n    """\n' in src
+
+    src = _function_source(nested_docstring_func)
+    assert "'''I have a docstring" in src
+    assert '"""SUPRISE! SO DO I!"""' in src
+
+    src = _class_source(SingleLineDocstringClass)
+    assert '    """I have a single line docstring"""\n' in src
+
+    src = _class_source(MultiLineDocstringClass)
+    assert '    """I have a docstring\n\n    with multiple lines\n    """\n' in src
+
+    src = _class_source(ClassWithMethodsWithDocstrings)
+    assert '        """I have a docstring"""\n' in src
+    assert '        """I have a docstring\n\n        with multiple lines\n        """\n' in src


### PR DESCRIPTION
Vscode and friends (cursor at least; idk about other IDEs) don't show docstrings for entities that are wrapped by synchronicity, because the language server primarily uses the type stub files (I guess).

This PR propagates docstrings into the type stubs so that they appear in more places:

Previously:

<img width="671" alt="image" src="https://github.com/user-attachments/assets/5fc0047a-4ccc-45f4-b3b7-7f3f6eecaa5e" />

Now:

<img width="723" alt="image" src="https://github.com/user-attachments/assets/8d030c44-3400-476a-988e-df2ceeda4318" />
