### PR TITLE
Relax test for windows timing

### DIFF
--- a/test/exception_test.py
+++ b/test/exception_test.py
@@ -27,10 +27,12 @@ import concurrent
 import functools
 import inspect
 import pytest
+import sys
 import time
 import typing
 
 SLEEP_DELAY = 0.1
+WINDOWS_TIME_RESOLUTION_FIX = 0.01 if sys.platform == "win32" else 0.0
 
 
 class CustomExceptionCause(Exception):
@@ -56,7 +58,7 @@ def test_function_raises_sync(synchronizer):
     with pytest.raises(CustomException) as exc:
         f_raises_s = synchronizer.create_blocking(f_raises)
         f_raises_s()
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert exc.value.__suppress_context__ or exc.value.__context__ is None
 
 
@@ -65,7 +67,7 @@ def test_function_raises_with_cause_sync(synchronizer):
     with pytest.raises(CustomException) as exc:
         f_raises_s = synchronizer.create_blocking(f_raises_with_cause)
         f_raises_s()
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert isinstance(exc.value.__cause__, CustomExceptionCause)
 
 
@@ -77,7 +79,7 @@ def test_function_raises_sync_futures(synchronizer):
     assert time.monotonic() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
         fut.result()
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert exc.value.__suppress_context__ or exc.value.__context__ is None
 
 
@@ -89,7 +91,7 @@ def test_function_raises_with_cause_sync_futures(synchronizer):
     assert time.monotonic() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
         fut.result()
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert isinstance(exc.value.__cause__, CustomExceptionCause)
 
 
@@ -102,7 +104,7 @@ async def test_function_raises_async(synchronizer):
     assert time.monotonic() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
         await coro
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert exc.value.__suppress_context__ or exc.value.__context__ is None
 
 
@@ -116,7 +118,7 @@ async def test_function_raises_with_cause_async(synchronizer):
     with pytest.raises(CustomException) as exc:
         await coro
     dur = time.monotonic() - t0
-    assert SLEEP_DELAY <= dur < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= dur < 2 * SLEEP_DELAY
     assert isinstance(exc.value.__cause__, CustomExceptionCause)
 
 
@@ -130,7 +132,7 @@ def test_function_raises_baseexc_sync(synchronizer):
     with pytest.raises(BaseException) as exc:
         f_raises_baseexc_s = synchronizer.create_blocking(f_raises_baseexc)
         f_raises_baseexc_s()
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert exc.value.__suppress_context__ or exc.value.__context__ is None
 
 
@@ -147,7 +149,7 @@ async def test_function_raises_async_syncwrap(synchronizer):
     assert time.monotonic() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
         await coro
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert exc.value.__suppress_context__ or exc.value.__context__ is None
 
 
@@ -164,7 +166,7 @@ async def test_function_raises_with_cause_async_syncwrap(synchronizer):
     assert time.monotonic() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
         await coro
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert isinstance(exc.value.__cause__, CustomExceptionCause)
 
 
@@ -188,5 +190,5 @@ async def test_wrapped_function_raises_async(synchronizer):
     assert time.monotonic() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException) as exc:
         await coro
-    assert SLEEP_DELAY <= time.monotonic() - t0 < 2 * SLEEP_DELAY
+    assert SLEEP_DELAY - WINDOWS_TIME_RESOLUTION_FIX <= time.monotonic() - t0 < 2 * SLEEP_DELAY
     assert exc.value.__suppress_context__ or exc.value.__context__ is None


### PR DESCRIPTION
Tests keep flaking in unreasonable ways on windows (asyncio.sleep(0.1) taking less than 0.1 seconds according to monotonic clock...).
