### PR TITLE
Fix test flake w/ leaked resources

### DIFF
--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -6,17 +6,17 @@ from pathlib import Path
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows can't fork")
 def test_fork_restarts_loop():
-    p = subprocess.Popen(
+    with subprocess.Popen(
         [sys.executable, Path(__file__).parent / "support" / "_forker.py"],
         encoding="utf8",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-    )
-    try:
-        stdout, stderr = p.communicate(timeout=2)
-    except subprocess.TimeoutExpired:
-        p.kill()
-        assert False, "Fork process hanged"
+    ) as p:
+        try:
+            stdout, stderr = p.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            assert False, "Fork process hanged"
 
-    assert p.returncode == 0
-    assert stdout == "done\ndone\n"
+        assert p.returncode == 0
+        assert stdout == "done\ndone\n"

--- a/test/getattr_test.py
+++ b/test/getattr_test.py
@@ -3,7 +3,8 @@ import pytest
 from typing import Any, Dict
 
 
-def test_getattr(synchronizer):
+@pytest.mark.asyncio
+async def test_getattr(synchronizer):
     class Foo:
         _attrs: Dict[str, Any]
 
@@ -29,11 +30,12 @@ def test_getattr(synchronizer):
         def make_foo():
             return Foo()
 
+    # original type tests:
     foo = Foo()
     foo.x = 42
-    assert asyncio.run(foo.x) == 42
+    assert await foo.x == 42
     with pytest.raises(KeyError):
-        asyncio.run(foo.y)
+        await foo.y
     assert foo.z == 42
 
     BlockingFoo = synchronizer.create_blocking(Foo)
@@ -50,4 +52,4 @@ def test_getattr(synchronizer):
     assert isinstance(blocking_foo, BlockingFoo)
 
     # TODO: there is no longer a way to make async properties, but there is this w/ async __getattr__:
-    assert asyncio.run(blocking_foo.__getattr__.aio("x")) == 44
+    assert await blocking_foo.__getattr__.aio("x") == 44

--- a/test/type_stub_e2e_test.py
+++ b/test/type_stub_e2e_test.py
@@ -19,13 +19,13 @@ class FailedMyPyCheck(Exception):
 
 
 def run_mypy(input_file, print_errors=True):
-    p = subprocess.Popen(["mypy", input_file], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
-    result_code = p.wait()
-    if result_code != 0:
-        mypy_report = p.stdout.read().decode("utf8")
-        if print_errors:
-            print(mypy_report, file=sys.stderr)
-        raise FailedMyPyCheck(mypy_report)
+    with subprocess.Popen(["mypy", input_file], stderr=subprocess.STDOUT, stdout=subprocess.PIPE) as p:
+        result_code = p.wait()
+        if result_code != 0:
+            mypy_report = p.stdout.read().decode("utf8")
+            if print_errors:
+                print(mypy_report, file=sys.stderr)
+            raise FailedMyPyCheck(mypy_report)
 
 
 @contextmanager


### PR DESCRIPTION
* Fixes unclosed event loop warning (caused by an interaction between pytest_asyncio async tests and non-async tests running asyncio.run())
* Fixes unclosed file descriptor warning (subprocess usage without context manager)