### PR TITLE
Release 0.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.10.0"
+version = "0.10.1"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
* Cleaner tracebacks for Python 3.11+ (and adds env var SYNCHRONICITY_TRACEBACK=1 to get full tracebacks)