### PR TITLE
Make sigtools an extra dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ Static type support for wrappers
 
 One issue with the wrapper functions and classes is that they will have different argument and return value types than the wrapped originals (e.g. an AsyncGenerator becomes a Generator after being wrapped). This type transformation can't easily be expressed statically in Python's typing system.
 
-For this reason, synchronicity includes a basic type stub (.pyi) generation tool (`python -m synchronicity.type_stubs`) that takes Python modules names as inputs and emits a `.pyi` file for each module with static types translating any synchronicity-wrapped classes or functions.
+For this reason, synchronicity includes a basic type stub (.pyi) compilation tool. This cli tool has some additional dependencies that you can install via `pip install synchronicity[compile]` (the `compile` extra is only needed for *generating* the type stubs, not using them - so you don't have to include it in distributed libraries using synchroncity).
+
+The cli tool `python -m synchronicity.type_stubs` takes Python modules names as inputs and emits `.pyi` files for each module. The type stubs have static types translating any synchronicity-wrapped classes or functions.
 
 Since the `.pyi` file will sometimes "shadow" the original file, which you still might want to type check for issues in the implementation code, a good practice is to separate wrappers and wrapped implementation code into separate modules and only emit type stubs for the "wrapper modules".  
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,19 @@ authors = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "sigtools>=4.0.1",
     "typing-extensions>=4.12.2",
 ]
+
 classifiers = [
   "Operating System :: OS Independent",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
 ]
 
+[project.optional-dependencies]
+compile = [
+    "sigtools>=4.0.1",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -43,6 +47,7 @@ exclude = [
 [dependency-groups]
 dev = [
     "pre-commit>=3.5.0",
+    "sigtools>=4.0.1",
     {include-group = "lint"},
     {include-group = "test"}
 ]


### PR DESCRIPTION
No need to have `sigtools` + (the transitive `attrs` dependency) as a runtime dependencies