### PR TITLE
Update pyproject.toml to fully remove 3.8 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Modal Labs" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "sigtools>=4.0.1",
     "typing-extensions>=4.12.2",


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of this change, then request review from a recent contributor.
-->

Using `type[BaseException]` requires python 3.9+:

https://github.com/modal-labs/synchronicity/blob/e807cb83ba40cd8df4fba67ef9fd85d778a3dfe4/src/synchronicity/exceptions.py#L83 uses 

With https://github.com/modal-labs/synchronicity/pull/193 3.8 was removed, so we need to update it from `pyproject.toml`.