### PR TITLE
Include classproperty methods in type stubs

### DIFF
--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -36,6 +36,7 @@ from synchronicity.synchronizer import (
     TARGET_INTERFACE_ATTR,
     FunctionWithAio,
     MethodWithAio,
+    classproperty,
 )
 
 logger = getLogger(__name__)
@@ -317,6 +318,11 @@ class StubEmitter:
                 if entity.fdel:
                     fn_source = self._get_function_source_with_overloads(entity.fdel, entity_name, body_indent_level)
                     methods.append(f"{body_indent}@{entity_name}.deleter\n{fn_source}")
+
+            elif isinstance(entity, classproperty):
+                fn_source = self._get_function_source_with_overloads(entity.fget, entity_name, body_indent_level)
+                methods.append(f"{body_indent}@synchronicity.classproperty\n{fn_source}")
+                self.imports.add("synchronicity")
 
             elif isinstance(entity, FunctionWithAio):
                 # Note: FunctionWithAio is used for staticmethods

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 import typing_extensions
 
 import synchronicity
-from synchronicity import overload_tracking
+from synchronicity import classproperty, overload_tracking
 from synchronicity.async_wrap import asynccontextmanager
 from synchronicity.type_stubs import StubEmitter
 
@@ -172,6 +172,10 @@ class MixedClass:
     def some_property(self, val):
         print(val)
 
+    @classproperty
+    def class_property(cls):
+        return 1
+
 
 def test_class_generation():
     emitter = StubEmitter(__name__)
@@ -188,6 +192,7 @@ def test_class_generation():
             last_assertion_location = new_location
 
     indent = "    "
+    assert_in_after_last("import synchronicity")
     assert_in_after_last("class MixedClass:")
     assert_in_after_last(f"{indent}class_var: str")
     assert_in_after_last(f"{indent}class_var: str")
@@ -197,6 +202,7 @@ def test_class_generation():
     assert_in_after_last(f"{indent}@property\n{indent}def some_property(self) -> str:")
     assert_in_after_last(f"{indent}@some_property.setter\n{indent}def some_property(self, val):")
     assert_in_after_last(f"{indent}@some_property.deleter\n{indent}def some_property(self, val):")
+    assert_in_after_last(f"{indent}@synchronicity.classproperty\n{indent}def class_property(cls):\n{indent * 2}...")
 
 
 def merged_signature(*sigs):


### PR DESCRIPTION
Followup to #213 

I'd rather we just handled class vars directly and didn't need to use `classproperty` to expose them but this at least makes that functional.