### PR TITLE
Use original name so that PYTHONASYNCIODEBUG=1 show it

### DIFF
--- a/src/synchronicity/exceptions.py
+++ b/src/synchronicity/exceptions.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 import os
 import sys
+from functools import wraps
 from pathlib import Path
 from types import TracebackType
 from typing import Literal, Optional
@@ -26,6 +27,7 @@ class UserCodeException(Exception):
 
 
 def wrap_coro_exception(coro):
+    @wraps(coro)
     async def coro_wrapped():
         try:
             return await coro

--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -13,6 +13,7 @@ import traceback
 import types
 import typing
 import warnings
+from functools import wraps
 from typing import Callable, ForwardRef, Optional
 
 import typing_extensions
@@ -255,6 +256,7 @@ Traceback:{self._thread_traceback}"""
         if not self._async_leakage_warning:
             return coro
 
+        @wraps(coro)
         async def coro_wrapped():
             value = await coro
             # TODO: we should include the name of the original function here

--- a/test/support/_blocking_func.py
+++ b/test/support/_blocking_func.py
@@ -1,0 +1,20 @@
+from synchronicity import Synchronizer
+from synchronicity.async_utils import Runner
+
+
+async def blocks_event_loop():
+    import time
+
+    time.sleep(0.5)
+
+
+s = Synchronizer()
+
+
+@s.wrap
+async def my_custom_coro_name():
+    await blocks_event_loop()
+
+
+with Runner() as runner:
+    runner.run(my_custom_coro_name.aio())

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -3,10 +3,12 @@ import concurrent.futures
 import inspect
 import logging
 import pytest
+import subprocess
 import sys
 import threading
 import time
 import typing
+from pathlib import Path
 from typing import Coroutine
 from unittest.mock import MagicMock
 
@@ -712,3 +714,10 @@ def test_synchronizer_unexpected_thread_death(caplog):
     assert "Traceback" in error_log.message
     assert "CustomError" in error_log.message
     s._close_loop()
+
+
+def test_synchronizer_exposes_names_in_debug_mode():
+    fn = Path(__file__).parent / "support" / "_blocking_func.py"
+
+    result = subprocess.run([sys.executable, fn], capture_output=True, text=True, env={"PYTHONASYNCIODEBUG": "1"})
+    assert "my_custom_coro_name" in result.stderr

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import gc
 import inspect
 import logging
+import os
 import pytest
 import subprocess
 import sys
@@ -720,7 +721,12 @@ def test_synchronizer_unexpected_thread_death(caplog):
 def test_synchronizer_exposes_names_in_debug_mode():
     fn = Path(__file__).parent / "support" / "_blocking_func.py"
 
-    result = subprocess.run([sys.executable, fn], capture_output=True, text=True, env={"PYTHONASYNCIODEBUG": "1"})
+    result = subprocess.run(
+        [sys.executable, fn],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONASYNCIODEBUG": "1"},
+    )
     assert "my_custom_coro_name" in result.stderr
 
 


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of this change, then request review from a recent contributor.
-->

When using `PYTHONASYNCIODEBUG=1`, the names of the original async functions are hidden. For example, on `main` and running with this file:

```python
from synchronicity import Synchronizer
from synchronicity.async_utils import Runner


async def blocks_event_loop():
    import time

    time.sleep(0.5)


s = Synchronizer()


@s.wrap
async def my_custom_name():
    await blocks_event_loop()


with Runner() as runner:
    runner.run(my_custom_name.aio())
```

I get this output:

```
Executing <Task finished name='Task-6' coro=<Synchronizer._wrap_check_async_leakage.<locals>.coro_wrapped() done, defined at .../synchronicity/synchronizer.py:258> result=None created at .../synchronicity/synchronizer.py:415> took 0.501 seconds
```

The `Synchronizer._wrap_check_async_leakage.<locals>.coro_wrapped` makes it harder to find where the issue is.