### PR TITLE
Support type stub gen when defining a Union with `|` 

### DIFF
--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -880,6 +880,9 @@ class StubEmitter:
 
             return repr(annotation)
 
+        # types.UnionType is the PEP 604 `X | Y` form. The local get_origin() maps it to
+        # typing.Union so it doesn't hit the `origin is None` branch above, which means
+        # execution always reaches here for native union syntax.
         if isinstance(annotation, types.UnionType):
             formatted_args = [self._formatannotation(a) for a in args]
             return " | ".join(formatted_args)

--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -880,6 +880,10 @@ class StubEmitter:
 
             return repr(annotation)
 
+        if isinstance(annotation, types.UnionType):
+            formatted_args = [self._formatannotation(a) for a in args]
+            return " | ".join(formatted_args)
+
         # generic:
         origin_name = get_specific_generic_name(annotation)
         if origin is contextlib.AbstractAsyncContextManager:

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -846,6 +846,13 @@ def test_union_pipe_syntax_in_variable_annotation():
     assert "x: int | str" in src
 
 
+def test_union_pipe_syntax_three_way():
+    s = StubEmitter(__name__)
+    s.add_variable(int | str | float, "x")
+    src = s.get_source()
+    assert "x: int | str | float" in src
+
+
 def test_union_type(tmp_path):
     contents = dedent(
         """

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -846,6 +846,24 @@ def test_union_pipe_syntax_in_variable_annotation():
     assert "x: int | str" in src
 
 
+def test_union_type(tmp_path):
+    contents = dedent(
+        """
+        foo: int | None = None
+        """
+    )
+    with open(fname := (tmp_path / "my_union.py"), "w") as f:
+        f.write(contents)
+
+    spec = importlib.util.spec_from_file_location("my_union", fname)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    emitter = StubEmitter.from_module(mod)
+    src = emitter.get_source()
+    assert "foo: int | None" in src
+
+
 def test_async_classmethod_gets_aio(synchronizer):
     @synchronizer.wrap
     class A:

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -320,7 +320,7 @@ def test_optional():
     src = _function_source(wrapped_f)
     # TODO: 3.14 does not preserve the typing.Optional[str]
     if sys.version_info[:2] == (3, 14):
-        assert "typing.Union[str, None]" in src
+        assert "str | None" in src
     elif sys.version_info[:2] >= (3, 10):
         assert "typing.Optional[str]" in src
     else:

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -838,6 +838,14 @@ def test_union_pipe_syntax_imports():
     assert "pandas.core.series.Series" in src_multi
 
 
+def test_union_pipe_syntax_in_variable_annotation():
+    """Regression: _formatannotation should handle types.UnionType (X | Y) directly."""
+    s = StubEmitter(__name__)
+    s.add_variable(int | str, "x")
+    src = s.get_source()
+    assert "x: int | str" in src
+
+
 def test_async_classmethod_gets_aio(synchronizer):
     @synchronizer.wrap
     class A:


### PR DESCRIPTION
This PR adds support for type stub generation when defining a Union with `|` in module scope.