### PR TITLE
Type stubs: Don't parse literal values when emitting type stubs

### DIFF
--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -158,6 +158,8 @@ def _get_type_vars(typ, synchronizer, home_module):
         param_spec = synchronizer._translate_out(param_spec)
         ret.add(param_spec)
     elif origin:
+        if origin in (typing.Literal, typing_extensions.Literal):
+            return ret
         for arg in safe_get_args(typ):
             ret |= _get_type_vars(arg, synchronizer, home_module)
     else:

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -1,6 +1,7 @@
 import collections
 import functools
 import importlib
+import logging
 import pathlib
 import pytest
 import sys
@@ -566,6 +567,20 @@ def test_typing_literal():
 
     src = _function_source(foo)
     assert "-> typing.Literal['three', 'str']" in src  # "str" should not be eval:ed in a Literal!
+
+
+def test_synchronicity_wrapped_literal_does_not_log_eval_error(caplog):
+    async def foo(kind: typing.Literal["users", "service_users"]) -> typing.Literal["viewer", "contributor"]:
+        return "viewer"
+
+    wrapped_foo = synchronizer.create_blocking(foo, name="wrapped_foo")
+
+    with caplog.at_level(logging.ERROR, logger="synchronicity.type_stubs"):
+        src = _function_source(wrapped_foo)
+
+    assert "Error when evaluating" not in caplog.text
+    assert "kind: typing.Literal['users', 'service_users']" in src
+    assert "-> typing.Literal['viewer', 'contributor']" in src
 
 
 def test_overloads_unwrapped_functions():


### PR DESCRIPTION
Fixes spammy errors when referencing literal values in some contexts while generating type stubs