### PR TITLE
Skip Literal args in _get_type_vars to avoid spurious warnings

### DIFF
--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -158,6 +158,8 @@ def _get_type_vars(typ, synchronizer, home_module):
         param_spec = synchronizer._translate_out(param_spec)
         ret.add(param_spec)
     elif origin:
+        if origin is typing.Literal:
+            return ret  # Literal args are values, not types
         for arg in safe_get_args(typ):
             ret |= _get_type_vars(arg, synchronizer, home_module)
     else:

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -568,17 +568,17 @@ def test_typing_literal():
     assert "-> typing.Literal['three', 'str']" in src  # "str" should not be eval:ed in a Literal!
 
 
-MemberRole = typing.Literal["viewer", "contributor"]
+LiteralAlias = typing.Literal["literal_value_1", "literal_value_2"]
 
 
 class _WithLiteralAnnotations:
-    async def list(self) -> dict[typing.Literal["users", "service_users"], dict[str, MemberRole]]:
-        return {"users": {}, "service_users": {}}
+    async def list(self) -> dict[typing.Literal["key_a", "key_b"], dict[str, LiteralAlias]]:
+        return {"key_a": {}, "key_b": {}}
 
     async def update(
         self,
         *,
-        users: typing.Optional[typing.Mapping[str, MemberRole]] = None,
+        items: typing.Optional[typing.Mapping[str, LiteralAlias]] = None,
     ) -> None:
         pass
 
@@ -602,8 +602,8 @@ def test_literal_in_wrapped_class_method(capfd):
 
     captured = capfd.readouterr()
     assert "Error when evaluating" not in captured.err
-    assert "typing.Literal['users', 'service_users']" in src
-    assert "typing.Literal['viewer', 'contributor']" in src
+    assert "typing.Literal['key_a', 'key_b']" in src
+    assert "typing.Literal['literal_value_1', 'literal_value_2']" in src
 
 
 def test_overloads_unwrapped_functions():

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -568,6 +568,44 @@ def test_typing_literal():
     assert "-> typing.Literal['three', 'str']" in src  # "str" should not be eval:ed in a Literal!
 
 
+MemberRole = typing.Literal["viewer", "contributor"]
+
+
+class _WithLiteralAnnotations:
+    async def list(self) -> dict[typing.Literal["users", "service_users"], dict[str, MemberRole]]:
+        return {"users": {}, "service_users": {}}
+
+    async def update(
+        self,
+        *,
+        users: typing.Optional[typing.Mapping[str, MemberRole]] = None,
+    ) -> None:
+        pass
+
+
+WithLiteralAnnotations = synchronizer.create_blocking(_WithLiteralAnnotations, "WithLiteralAnnotations", __name__)
+
+
+def test_literal_in_wrapped_class_method(capfd):
+    """Literal string args should not be evaluated as forward references."""
+    import logging
+
+    # Capture warnings from the synchronicity logger
+    logger = logging.getLogger("synchronicity")
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.WARNING)
+    logger.addHandler(handler)
+    try:
+        src = _class_source(WithLiteralAnnotations)
+    finally:
+        logger.removeHandler(handler)
+
+    captured = capfd.readouterr()
+    assert "Error when evaluating" not in captured.err
+    assert "typing.Literal['users', 'service_users']" in src
+    assert "typing.Literal['viewer', 'contributor']" in src
+
+
 def test_overloads_unwrapped_functions():
     with overload_tracking.patched_overload():
 


### PR DESCRIPTION
`_get_type_vars` recurses into generic type args to find TypeVars, but `Literal` args are values (strings, ints, etc.), not types. When a `Literal` like `Literal["users", "service_users"]` is encountered, `safe_get_args` returns bare strings which then hit the string annotation evaluation path, causing `NameError` warnings like:

```
Error when evaluating users in modal._environments. Falling back to string typ
NameError: name 'users' is not defined
```

This happens when generating type stubs for wrapped classes whose methods use `Literal` annotations (e.g. `dict[Literal["users", "service_users"], dict[str, Literal["viewer", "contributor"]]]`).

The fix short-circuits when `origin is typing.Literal` since `Literal` args can never contain TypeVars.