### PR TITLE
Avoid blocking the event loop during async loop startup

### DIFF
--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -285,6 +285,21 @@ Traceback:{self._thread_traceback}"""
             return self._start_loop()
         return self._loop
 
+    async def _get_loop_async(self) -> asyncio.AbstractEventLoop:
+        """Like _get_loop(start=True) but non-blocking for async callers.
+
+        _start_loop() blocks the calling thread while waiting for the
+        background thread to initialize. When the caller is itself an
+        async coroutine, that block stalls the event loop and can trigger
+        asyncio's slow-callback warning. This method offloads the
+        blocking startup to a thread-pool executor so the caller's
+        event loop stays responsive.
+        """
+        loop = self._get_loop(start=False)
+        if loop is not None:
+            return loop
+        return await asyncio.get_running_loop().run_in_executor(None, lambda: self._get_loop(start=True))
+
     def _get_running_loop(self):
         # TODO: delete this method
         try:
@@ -473,7 +488,7 @@ Traceback:{self._thread_traceback}"""
     async def _run_function_async(self, coro, original_func):
         coro = wrap_coro_exception(coro)
         coro = self._wrap_check_async_leakage(coro)
-        loop = self._get_loop(start=True)
+        loop = await self._get_loop_async()
         if self._is_inside_loop():
             value = await coro
         else:


### PR DESCRIPTION
`_run_function_async` called `_get_loop(start=True)` which synchronously blocks on `is_ready.wait()` while starting the Synchronizer's background thread. When called from an async context (e.g. via `.aio()`), this blocks the caller's event loop for the full duration of thread creation + event loop initialization.

On busy CI runners this can exceed asyncio's 0.1s slow-callback threshold. With `PYTHONASYNCIODEBUG=1` set by the test `conftest.py` (and inherited by subprocesses), the warning gets printed to stderr, failing `test_shutdown_during_async_run`'s `assert stderr == ""`.

**Fix**: Add `_get_loop_async()` which offloads the blocking `_start_loop()` to a thread-pool executor via `run_in_executor`, and use it in `_run_function_async`. The caller's event loop stays responsive during first-time loop initialization. The sync callers (`_run_function_sync`, `_run_function_sync_future`) are unchanged since they already block the calling thread.

**Issue:** N/A

Link to Devin session: https://modal.devinenterprise.com/sessions/bb383270f49d407bb997f528cf0f7c51
Requested by: @freider