### PR TITLE
Fix thread death detection race in _get_loop

### DIFF
--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -268,18 +268,27 @@ class Synchronizer:
     def _get_loop(self, start: bool) -> typing.Union[asyncio.AbstractEventLoop, None]: ...
 
     def _get_loop(self, start=False) -> typing.Union[asyncio.AbstractEventLoop, None]:
-        if self._thread and not self._thread.is_alive():
-            if self._owner_pid == os.getpid():
-                # warn - thread died without us forking
-                logger.error(
-                    f"""Synchronizer thread unexpectedly died.
+        if self._thread:
+            thread_dead = not self._thread.is_alive()
+            loop_closed = self._loop is not None and self._loop.is_closed()
+
+            if thread_dead or loop_closed:
+                if not thread_dead:
+                    # Loop is closed but thread hasn't fully exited yet - wait for
+                    # it so that _thread_exception/_thread_traceback are populated.
+                    self._thread.join(timeout=5.0)
+
+                if self._owner_pid == os.getpid():
+                    # warn - thread died without us forking
+                    logger.error(
+                        f"""Synchronizer thread unexpectedly died.
 Cause: {type(self._thread_exception)}
 Traceback:{self._thread_traceback}"""
-                )
-                raise RuntimeError("Synchronizer thread unexpectedly died")
+                    )
+                    raise RuntimeError("Synchronizer thread unexpectedly died")
 
-            self._thread = None
-            self._loop = None
+                self._thread = None
+                self._loop = None
 
         if self._loop is None and start:
             return self._start_loop()

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -680,7 +680,6 @@ def test_blocking_in_async_callback():
 
 
 @pytest.mark.filterwarnings("ignore")
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Test flakes on 3.14")
 def test_synchronizer_unexpected_thread_death(caplog):
     s = Synchronizer()
 


### PR DESCRIPTION
Race condition in `_get_loop`: when the synchronizer thread is dying, `asyncio.run()` closes the event loop *before* the thread fully exits. In this window, `_get_loop` only checked `thread.is_alive()` (still True), returned the closed loop, and `run_coroutine_threadsafe` raised `RuntimeError: Event loop is closed` instead of the expected `RuntimeError: Synchronizer thread unexpectedly died`.

Fix: also check `loop.is_closed()` in `_get_loop`. When the loop is closed but the thread hasn't fully exited, join the thread (so `_thread_exception`/`_thread_traceback` are populated), then proceed with the same error handling.

Also removes the `skipif` on Python 3.14 which was a workaround for this same race.

**Issue:** N/A

Link to Devin session: https://modal.devinenterprise.com/sessions/a03acc42333e4e5698d3af0cfc6fccfa
Requested by: @freider