### PR TITLE
Release 0.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synchronicity"
-version = "0.12.2"
+version = "0.12.3"
 description = "Export blocking and async library versions from a single async implementation"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
* Fix thread death detection race in _get_loop (#271)
* Support type stub generation for unions defined with `|` (#267)
* Skip Literal args in _get_type_vars to avoid spurious warnings (#269)
* Avoid blocking the event loop during async loop startup (#270)
* Remove pre-3.10 compatibility code in type stub generation (#272)
* Use original name so that PYTHONASYNCIODEBUG=1 shows it (#244)