### PR TITLE
Fix `TypedDict` stub generation

### DIFF
--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -21,7 +21,7 @@ import warnings
 from inspect import get_annotations
 from logging import getLogger
 from pathlib import Path
-from typing import TypeVar, TypedDict
+from typing import TypedDict, TypeVar
 from unittest import mock
 
 import sigtools.specifiers  # type: ignore

--- a/src/synchronicity/type_stubs.py
+++ b/src/synchronicity/type_stubs.py
@@ -21,7 +21,7 @@ import warnings
 from inspect import get_annotations
 from logging import getLogger
 from pathlib import Path
-from typing import TypeVar
+from typing import TypeVar, TypedDict
 from unittest import mock
 
 import sigtools.specifiers  # type: ignore
@@ -802,7 +802,12 @@ class StubEmitter:
         if origin is None or not args:
             if annotation == Ellipsis:
                 return "..."
-            if isinstance(annotation, type) or isinstance(annotation, (TypeVar, typing_extensions.ParamSpec)):
+
+            if (
+                annotation == TypedDict
+                or isinstance(annotation, type)
+                or isinstance(annotation, (TypeVar, typing_extensions.ParamSpec))
+            ):
                 if annotation is type(None):  # check for "NoneType"
                     return "None"
                 name = (
@@ -819,6 +824,7 @@ class StubEmitter:
                         " to specify target module on a blocking type?"
                     )
                 return annotation_module + "." + name
+
             if isinstance(annotation, list):
                 # e.g. first argument to typing.Callable
                 subargs = ",".join([self._formatannotation(arg) for arg in annotation])

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -946,4 +946,3 @@ def test_typeddict_base(tmp_path):
     emitter = StubEmitter.from_module(mod)
     src = emitter.get_source()
     assert "class A(typing.TypedDict):" in src
-    

--- a/test/type_stub_test.py
+++ b/test/type_stub_test.py
@@ -925,3 +925,25 @@ def test_async_classmethod_gets_aio(synchronizer):
     assert "foo: typing.ClassVar[__foo_spec" in src
     assert "async def aio(self" in src
     assert "def __call__(self" in src
+
+
+def test_typeddict_base(tmp_path):
+    contents = dedent(
+        """
+        from typing import TypedDict
+
+        class A(TypedDict):
+            a: int
+        """
+    )
+    with open(fname := (tmp_path / "my_union.py"), "w") as f:
+        f.write(contents)
+
+    spec = importlib.util.spec_from_file_location("my_union", fname)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    emitter = StubEmitter.from_module(mod)
+    src = emitter.get_source()
+    assert "class A(typing.TypedDict):" in src
+    


### PR DESCRIPTION
Code generated by `type_stubs` would not correctly render classes that based `TypedDict`:

Previous:
```
class TestClass(<function TypedDict at 0x7f67a04cf2e0>):
    test: str
```

New:
```
class TestClass(typing.TypedDict):
    test: str
```

**Issue:** N/A
