### PR TITLE
Preserve TypeError when instance method is called on wrapped class without an instance

### DIFF
--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -811,8 +811,8 @@ Traceback:{self._thread_traceback}"""
             try:
                 instance = self.__dict__[synchronizer_self._original_attr]
             except (KeyError, AttributeError):
-                # sdk671 - If self is not the wrapped class, fallback to calling
-                # the wrapped method on self
+                # If self is not a wrapped instance, call the method directly so that
+                # user-defined checks on the underlying method can raise meaningful errors.
                 return wrapped_method(self, *args, **kwargs)
             with suppress_synchronicity_tb_frames():
                 try:

--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -171,7 +171,6 @@ class Synchronizer:
         self._nowrap_attr = "_sync_nonwrap_%d" % id(self)
         self._input_translation_attr = "_sync_input_translation_%d" % id(self)
         self._output_translation_attr = "_sync_output_translation_%d" % id(self)
-        self._run_before_attr = "_sync_run_before_%d" % id(self)
 
         # Prep a synchronized context manager in case one is returned and needs translation
         self._ctx_mgr_cls = contextlib._AsyncGeneratorContextManager
@@ -809,8 +808,6 @@ Traceback:{self._thread_traceback}"""
 
         @wraps_by_interface(interface, wrapped_method)
         def proxy_method(self, *args, **kwargs):
-            if hook := getattr(method, synchronizer_self._run_before_attr, None):
-                hook(self)
             try:
                 instance = self.__dict__[synchronizer_self._original_attr]
             except (KeyError, AttributeError):
@@ -1045,12 +1042,6 @@ Traceback:{self._thread_traceback}"""
     def nowrap(self, obj):
         setattr(obj, self._nowrap_attr, True)
         return obj
-
-    def run_before(self, func):
-        def wrapper(obj):
-            setattr(obj, self._run_before_attr, func)
-            return obj
-        return wrapper
 
     def no_input_translation(self, obj):
         setattr(obj, self._input_translation_attr, False)

--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -811,6 +811,8 @@ Traceback:{self._thread_traceback}"""
             try:
                 instance = self.__dict__[synchronizer_self._original_attr]
             except (KeyError, AttributeError):
+                # sdk671 - If self is not the wrapped class, fallback to calling
+                # the wrapped method on self
                 return wrapped_method(self, *args, **kwargs)
             with suppress_synchronicity_tb_frames():
                 try:

--- a/src/synchronicity/synchronizer.py
+++ b/src/synchronicity/synchronizer.py
@@ -171,6 +171,7 @@ class Synchronizer:
         self._nowrap_attr = "_sync_nonwrap_%d" % id(self)
         self._input_translation_attr = "_sync_input_translation_%d" % id(self)
         self._output_translation_attr = "_sync_output_translation_%d" % id(self)
+        self._run_before_attr = "_sync_run_before_%d" % id(self)
 
         # Prep a synchronized context manager in case one is returned and needs translation
         self._ctx_mgr_cls = contextlib._AsyncGeneratorContextManager
@@ -808,7 +809,12 @@ Traceback:{self._thread_traceback}"""
 
         @wraps_by_interface(interface, wrapped_method)
         def proxy_method(self, *args, **kwargs):
-            instance = self.__dict__[synchronizer_self._original_attr]
+            if hook := getattr(method, synchronizer_self._run_before_attr, None):
+                hook(self)
+            try:
+                instance = self.__dict__[synchronizer_self._original_attr]
+            except (KeyError, AttributeError):
+                return wrapped_method(self, *args, **kwargs)
             with suppress_synchronicity_tb_frames():
                 try:
                     return wrapped_method(instance, *args, **kwargs)
@@ -1039,6 +1045,12 @@ Traceback:{self._thread_traceback}"""
     def nowrap(self, obj):
         setattr(obj, self._nowrap_attr, True)
         return obj
+
+    def run_before(self, func):
+        def wrapper(obj):
+            setattr(obj, self._run_before_attr, func)
+            return obj
+        return wrapper
 
     def no_input_translation(self, obj):
         setattr(obj, self._input_translation_attr, False)

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -873,3 +873,31 @@ def test_del_is_not_wrapped(synchronizer):
         "init A",
         "del A",
     ]
+
+
+def test_instance_method_called_on_class_passes_through(synchronizer):
+    # Calling an instance method on the wrapped class with a non-instance as self
+    # should propagate to the underlying method so that user-defined checks can raise
+    # meaningful errors. Without the fallback, the proxy crashes first with an obscure
+    # error.
+    class _Foo:
+        def foo(self):
+            if not isinstance(self, _Foo):
+                raise ValueError(f"Expected _Foo instance, got {type(self).__name__}")
+            return "Foo!"
+
+    Foo = synchronizer.wrap(_Foo)
+
+    with pytest.raises(ValueError, match="Expected _Foo instance, got str"):
+        Foo.foo("not_a_foo_instance")
+
+    class _Bar:
+        def bar(self, x):
+            return f"Bar! {x}"
+
+    Bar = synchronizer.wrap(_Bar)
+
+    import re
+
+    with pytest.raises(TypeError, match=re.escape("blocking_bar() missing 1 required positional argument: 'self'")):
+        Bar.bar()

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -897,7 +897,5 @@ def test_instance_method_called_on_class_passes_through(synchronizer):
 
     Bar = synchronizer.wrap(_Bar)
 
-    import re
-
-    with pytest.raises(TypeError, match=re.escape("blocking_bar() missing 1 required positional argument: 'self'")):
+    with pytest.raises(TypeError, match="missing 1 required positional argument: 'x'"):
         Bar.bar("foo")

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -900,4 +900,4 @@ def test_instance_method_called_on_class_passes_through(synchronizer):
     import re
 
     with pytest.raises(TypeError, match=re.escape("blocking_bar() missing 1 required positional argument: 'self'")):
-        Bar.bar()
+        Bar.bar("foo")


### PR DESCRIPTION
<!--
  ✍️ Write a short summary of this change, then request review from a recent contributor.
-->

**Issue:** N/A

When you have a wrapped class and call a method on the class instead of the instance, you don't get a `TypeError`. You get a confusing error arising from synchronicity.

```python
class _Bar:
    def bar(self, x):
        return f"Bar! {x}"

Bar = synchronizer.wrap(_Bar)

Bat.bar("foo")

> raises AttributeError: 'str' object has no attribute '__dict__'
```

This is confusing especially when doing something like `Image.pip_install`. With this change, the type error is preserved.

This approach also lets us raise a clearer message from the raised class.